### PR TITLE
feat: use negative range requests to save HEAD round trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 .clangd
+.DS_Store

--- a/packages/file-reader/src/lib/backends/OmFileReaderBackend.ts
+++ b/packages/file-reader/src/lib/backends/OmFileReaderBackend.ts
@@ -8,6 +8,14 @@ export interface OmFileReaderBackend {
   getBytes(offset: number, size: number): Promise<Uint8Array>;
 
   /**
+   * Get bytes from the end of file. Optional optimization for HTTP backends
+   * to avoid a separate HEAD request when reading the trailer.
+   * Returns data and file size in a single request.
+   * @param size The number of bytes to read from the end
+   */
+  getBytesFromEnd?(size: number): Promise<{ data: Uint8Array; fileSize: number }>;
+
+  /**
    * Tell the backend to prefetch data at the specified offset and size
    * @param offset The offset in bytes from the start of the file
    * @param size The number of bytes to prefetch

--- a/packages/file-reader/src/lib/backends/OmHttpBackend.ts
+++ b/packages/file-reader/src/lib/backends/OmHttpBackend.ts
@@ -157,6 +157,59 @@ export class OmHttpBackend implements OmFileReaderBackend {
     return data;
   }
 
+  /**
+   * Get bytes from the end of file using negative Range request.
+   * Returns data and file size in a single request (saves HEAD round trip).
+   */
+  async getBytesFromEnd(size: number): Promise<{ data: Uint8Array; fileSize: number }> {
+    if (size <= 0) {
+      throw new OmHttpBackendError("Invalid size");
+    }
+
+    const headers: Record<string, string> = {
+      Range: `bytes=-${size}`,
+    };
+
+    if (this.debug) {
+      console.log(`Getting last ${size} bytes from ${this.url}`);
+    }
+
+    const response = await fetchRetry(this.url, { headers }, this.timeoutMs, this.retries);
+
+    if (response.status !== 206) {
+      throw new OmHttpBackendError(`Expected 206 Partial Content, got ${response.status}`, response.status);
+    }
+
+    // Parse Content-Range header: "bytes START-END/TOTAL"
+    const contentRange = response.headers.get("content-range");
+    if (!contentRange) {
+      throw new OmHttpBackendError("Content-Range header missing from response");
+    }
+
+    const match = contentRange.match(/bytes\s+(\d+)-(\d+)\/(\d+)/);
+    if (!match) {
+      throw new OmHttpBackendError(`Invalid Content-Range header: ${contentRange}`);
+    }
+
+    const fileSize = parseInt(match[3], 10);
+
+    // Cache metadata for subsequent requests
+    if (this.fileSize === null) {
+      this.fileSize = fileSize;
+      this.lastModified = response.headers.get("last-modified");
+      this.eTag = response.headers.get("etag");
+    }
+
+    const buffer = await response.arrayBuffer();
+    const data = new Uint8Array(buffer);
+
+    if (data.length !== size) {
+      throw new OmHttpBackendError(`Received ${data.length} bytes, expected ${size}`);
+    }
+
+    return { data, fileSize };
+  }
+
   async prefetchData(_offset: number, _bytes: number): Promise<void> {
     // No-op for now!
   }


### PR DESCRIPTION
Hi,

When reading the file trailer, use Range: bytes=-N instead of first doing a HEAD request to get file size. The Content-Range response header provides the file size.

This saves one HTTP round trip when initializing OmFileReader with OmHttpBackend.

```
  # Negative range request - gets last 24 bytes + file size in one request
  curl -sI -H "Range: bytes=-24" "https://openmeteo.s3.amazonaws.com/data_spatial/ecmwf_ifs/2025/12/19/0000Z/2025-12-19T0000.om"

  # Result:
  # HTTP/1.1 206 Partial Content
  # Content-Range: bytes 112449160-112449183/112449184  ← file size = 112449184
  # Content-Length: 24
```

Frohe Feiertage :)