### PR TITLE
fix: unify types between browser and node

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Usage depends on the backend you want to use to access the data and the environm
 ### Node.js: Reading from a Local File
 
 ```typescript
-import { OmFileReader, FileBackendNode, OmDataType } from "@openmeteo/file-reader";
+import { OmFileReader, FileBackend, OmDataType } from "@openmeteo/file-reader";
 
-const backend = new FileBackendNode("/path/to/your/file.om");
+const backend = new FileBackend("/path/to/your/file.om");
 const reader = await OmFileReader.create(backend);
 // this selects all data of all dimensions
 // If the array you are reading is too big, this might result in OOM

--- a/packages/file-reader/README.md
+++ b/packages/file-reader/README.md
@@ -84,9 +84,9 @@ console.log(arr);
 ### Node.js: Reading from a Local File
 
 ```typescript
-import { OmFileReader, FileBackendNode, OmDataType } from "@openmeteo/file-reader";
+import { OmFileReader, FileBackend, OmDataType } from "@openmeteo/file-reader";
 
-const backend = new FileBackendNode("/path/to/your/file.om");
+const backend = new FileBackend("/path/to/your/file.om");
 const reader = await OmFileReader.create(backend);
 // this selects all data of all dimensions
 // If the array you are reading is too big, this might result in OOM

--- a/packages/file-reader/package.json
+++ b/packages/file-reader/package.json
@@ -8,23 +8,20 @@
     "directory": "packages/file-reader"
   },
   "type": "module",
-  "exports": {
-    ".": {
-      "browser": {
-        "types": "./dist/index.browser.d.ts",
-        "import": "./dist/esm/index.browser.js",
-        "require": "./dist/cjs/index.browser.cjs"
-      },
-      "default": {
-        "types": "./dist/index.node.d.ts",
-        "import": "./dist/esm/index.js",
-        "require": "./dist/cjs/index.cjs"
-      }
-    }
-  },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "import": {
+      "browser": "./dist/esm/index.browser.js",
+      "default": "./dist/esm/index.js"
+    },
+    "require": {
+      "browser": "./dist/cjs/index.browser.cjs",
+      "default": "./dist/cjs/index.cjs"
+    }
+  },
   "scripts": {
     "build": "rollup -c",
     "test": "vitest",

--- a/packages/file-reader/package.json
+++ b/packages/file-reader/package.json
@@ -9,18 +9,22 @@
   },
   "type": "module",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": {
-      "browser": "./dist/esm/index.browser.js",
-      "default": "./dist/esm/index.js"
-    },
-    "require": {
-      "browser": "./dist/cjs/index.browser.cjs",
-      "default": "./dist/cjs/index.cjs"
+    ".": {
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "import": "./dist/esm/index.browser.js",
+        "require": "./dist/cjs/index.browser.cjs"
+      },
+      "default": {
+        "types": "./dist/index.node.d.ts",
+        "import": "./dist/esm/index.js",
+        "require": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "rollup -c",
     "test": "vitest",

--- a/packages/file-reader/src/index.node.ts
+++ b/packages/file-reader/src/index.node.ts
@@ -1,8 +1,9 @@
 export { OmFileReader } from "./lib/OmFileReader";
-export { FileBackendNode } from "./lib/backends/FileBackendNode";
+export { FileBackendNode as FileBackend } from "./lib/backends/FileBackendNode";
 export { MemoryHttpBackend } from "./lib/backends/MemoryHttpBackend";
 export { OmHttpBackend } from "./lib/backends/OmHttpBackend";
 export { BlockCacheBackend } from "./lib/backends/BlockCacheBackend";
+export { BrowserBlockCache } from "./lib/BrowserBlockCache";
 export { BlockCache, LruBlockCache } from "./lib/BlockCache";
 export { OmFileReaderBackend } from "./lib/backends/OmFileReaderBackend";
 export { initWasm, getWasmModule } from "./lib/wasm";

--- a/packages/file-reader/src/index.types.ts
+++ b/packages/file-reader/src/index.types.ts
@@ -1,3 +1,4 @@
-// types-only entry: re-export types from both entrypoints
+// types-only entry: re-export types from the canonical entrypoint.
+// We export from node here because it contains the shared names.
+// If there are browser-only types, add explicit re-exports below.
 export * from "./index.node";
-export * from "./index.browser";

--- a/packages/file-reader/src/index.types.ts
+++ b/packages/file-reader/src/index.types.ts
@@ -1,4 +1,3 @@
 // types-only entry: re-export types from the canonical entrypoint.
-// We export from node here because it contains the shared names.
-// If there are browser-only types, add explicit re-exports below.
+// We export from node here because it's the default entrypoint.
 export * from "./index.node";

--- a/packages/file-reader/src/lib/BlockCache.ts
+++ b/packages/file-reader/src/lib/BlockCache.ts
@@ -30,7 +30,7 @@ export class LruBlockCache implements BlockCache {
   private readonly cache = new Map<bigint, Uint8Array>();
   private readonly inflight = new Map<bigint, Promise<Uint8Array>>();
 
-  constructor(blockSize: number = 64 * 1024, maxBlocks: number = 128) {
+  constructor(blockSize: number = 64 * 1024, maxBlocks: number = 256) {
     this._blockSize = blockSize;
     this.maxBlocks = maxBlocks;
   }

--- a/packages/file-reader/src/lib/BlockCache.ts
+++ b/packages/file-reader/src/lib/BlockCache.ts
@@ -30,7 +30,7 @@ export class LruBlockCache implements BlockCache {
   private readonly cache = new Map<bigint, Uint8Array>();
   private readonly inflight = new Map<bigint, Promise<Uint8Array>>();
 
-  constructor(blockSize: number = 64 * 1024, maxBlocks: number = 256) {
+  constructor(blockSize: number = 64 * 1024, maxBlocks: number = 128) {
     this._blockSize = blockSize;
     this.maxBlocks = maxBlocks;
   }

--- a/packages/file-reader/src/lib/BrowserBlockCache.ts
+++ b/packages/file-reader/src/lib/BrowserBlockCache.ts
@@ -78,6 +78,12 @@ export class BrowserBlockCache implements BlockCache<string> {
   private readonly fetchQueue: Array<() => void> = [];
 
   constructor(options: BrowserBlockCacheOptions = {}) {
+    // Guard early to make misuse in SSR immediate and clear
+    if (typeof window === "undefined" && typeof self === "undefined" && typeof caches === "undefined") {
+      throw new Error(
+        "BrowserBlockCache is browser-only. Import it dynamically in the client (e.g. inside onMount())."
+      );
+    }
     this._blockSize = options.blockSize ?? 64 * 1024;
     this.cacheName = options.cacheName ?? "om-file-cache";
     this.memCacheTtlMs = options.memCacheTtlMs ?? 1000;

--- a/packages/file-reader/src/lib/BrowserBlockCache.ts
+++ b/packages/file-reader/src/lib/BrowserBlockCache.ts
@@ -78,8 +78,8 @@ export class BrowserBlockCache implements BlockCache<string> {
   private readonly fetchQueue: Array<() => void> = [];
 
   constructor(options: BrowserBlockCacheOptions = {}) {
-    // Guard early to make misuse in SSR immediate and clear
-    if (typeof window === "undefined" && typeof self === "undefined" && typeof caches === "undefined") {
+    // Guard early to make misuse in SSR or non-Cache environments immediate and clear
+    if (typeof caches === "undefined") {
       throw new Error(
         "BrowserBlockCache is browser-only. Import it dynamically in the client (e.g. inside onMount())."
       );

--- a/packages/file-reader/src/lib/backends/FileBackend.ts
+++ b/packages/file-reader/src/lib/backends/FileBackend.ts
@@ -1,3 +1,4 @@
+import { FileSource } from "../types";
 import { OmFileReaderBackend } from "./OmFileReaderBackend";
 
 export class FileBackend implements OmFileReaderBackend {
@@ -5,7 +6,7 @@ export class FileBackend implements OmFileReaderBackend {
   private memory: Uint8Array | null = null;
   private fileSize: number = 0;
 
-  constructor(source: File | Blob | Uint8Array | ArrayBuffer) {
+  constructor(source: FileSource) {
     if (typeof File !== "undefined" && source instanceof File) {
       this.fileObj = source;
       this.fileSize = source.size;

--- a/packages/file-reader/src/lib/backends/FileBackendNode.ts
+++ b/packages/file-reader/src/lib/backends/FileBackendNode.ts
@@ -1,3 +1,4 @@
+import { FileSource } from "../types";
 import { OmFileReaderBackend } from "./OmFileReaderBackend";
 import fs from "node:fs/promises";
 
@@ -7,7 +8,7 @@ export class FileBackendNode implements OmFileReaderBackend {
   private fileSize: number = 0;
   private fileHandle: fs.FileHandle | null = null;
 
-  constructor(source: string | Uint8Array | ArrayBuffer) {
+  constructor(source: FileSource) {
     if (typeof source === "string") {
       this.filePath = source;
     } else if (source instanceof ArrayBuffer) {
@@ -17,7 +18,7 @@ export class FileBackendNode implements OmFileReaderBackend {
       this.memory = source;
       this.fileSize = source.length;
     } else {
-      throw new Error("Unsupported file source type for Node.js FileBackendNode");
+      throw new Error("Unsupported file source type for Node.js FileBackend");
     }
   }
 

--- a/packages/file-reader/src/lib/types.ts
+++ b/packages/file-reader/src/lib/types.ts
@@ -92,3 +92,5 @@ export type OmDataTypeToTypedArray = {
   [OmDataType.FloatArray]: Float32Array;
   [OmDataType.DoubleArray]: Float64Array;
 };
+
+export type FileSource = string | File | Blob | Uint8Array | ArrayBuffer;


### PR DESCRIPTION
### Summary

- Introduced a unified FileSource type combining browser and node file source types
- Aliased FileBackendNode as FileBackend in the node entrypoint to match the browser export name
- Added SSR runtime guard to BrowserBlockCache constructor
