### PR TITLE
feat: file-format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.16",
       "workspaces": [
         "packages/file-format-wasm",
+        "packages/file-format",
         "packages/file-reader"
       ],
       "devDependencies": {
@@ -785,6 +786,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@openmeteo/file-format": {
+      "resolved": "packages/file-format",
+      "link": true
     },
     "node_modules/@openmeteo/file-format-wasm": {
       "resolved": "packages/file-format-wasm",
@@ -3073,6 +3078,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/file-format": {
+      "name": "@openmeteo/file-format",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
+    },
     "packages/file-format-wasm": {
       "name": "@openmeteo/file-format-wasm",
       "version": "0.0.16",
@@ -3083,7 +3095,7 @@
       "version": "0.0.16",
       "license": "GPL-2.0-only",
       "dependencies": {
-        "@openmeteo/file-format-wasm": "^0.0.16"
+        "@openmeteo/file-format": "*"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "workspaces": [
     "packages/file-format-wasm",
+    "packages/file-format",
     "packages/file-reader"
   ],
   "scripts": {
     "build:wasm": "npm run build --workspace=packages/file-format-wasm",
+    "build:format": "npm run build --workspace=packages/file-format",
     "build:js": "npm run build --workspace=packages/file-reader",
-    "build": "npm run build:wasm && npm run build:js",
+    "build": "npm run build:wasm && npm run build:format && npm run build:js",
     "test": "npm run test --workspace=packages/file-reader",
     "clean": "npm run clean --workspace=packages",
     "publish:wasm": "npm run build --workspace=packages/file-format-wasm && npm publish --workspace=packages/file-format-wasm --access public",

--- a/packages/file-format/package.json
+++ b/packages/file-format/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@openmeteo/file-format",
+  "version": "0.0.1",
+  "description": "Pure TypeScript implementation of the OM file format codec",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/file-format/src/constants.ts
+++ b/packages/file-format/src/constants.ts
@@ -1,0 +1,100 @@
+// constants.ts — OM file format enums and constants
+
+export const enum OmDataType {
+  None = 0,
+  Int8 = 1,
+  Uint8 = 2,
+  Int16 = 3,
+  Uint16 = 4,
+  Int32 = 5,
+  Uint32 = 6,
+  Int64 = 7,
+  Uint64 = 8,
+  Float = 9,
+  Double = 10,
+  String = 11,
+  Int8Array = 12,
+  Uint8Array = 13,
+  Int16Array = 14,
+  Uint16Array = 15,
+  Int32Array = 16,
+  Uint32Array = 17,
+  Int64Array = 18,
+  Uint64Array = 19,
+  FloatArray = 20,
+  DoubleArray = 21,
+  StringArray = 22,
+}
+
+export const enum OmCompression {
+  PforDelta2dInt16 = 0,
+  FpxXor2d = 1,
+  PforDelta2d = 2,
+  PforDelta2dInt16Logarithmic = 3,
+  None = 4,
+}
+
+export const enum OmError {
+  Ok = 0,
+  InvalidCompressionType = 1,
+  InvalidDataType = 2,
+  OutOfBoundRead = 3,
+  NotAnOmFile = 4,
+  DeflatedSizeMismatch = 5,
+  InvalidDimensions = 6,
+  InvalidChunkDimensions = 7,
+  InvalidReadOffset = 8,
+  InvalidReadCount = 9,
+  InvalidCubeOffset = 10,
+}
+
+export const enum OmHeaderType {
+  Invalid = 0,
+  Legacy = 1,
+  ReadTrailer = 2,
+}
+
+// Size of the V1 header (OmHeaderV1_t struct)
+export const OM_HEADER_V1_SIZE = 40;
+
+// Size of the V3 trailer (OmTrailer_t struct) = magic(2) + version(1) + padding(5) + offset(8) + size(8)
+export const OM_TRAILER_SIZE = 24;
+
+// Number of chunks per LUT chunk in V3 files
+export const LUT_CHUNK_COUNT = 64;
+
+// Bytes per element for each data type
+export function bytesPerElement(dataType: OmDataType): number {
+  switch (dataType) {
+    case OmDataType.Int8Array:
+    case OmDataType.Uint8Array:
+      return 1;
+    case OmDataType.Int16Array:
+    case OmDataType.Uint16Array:
+      return 2;
+    case OmDataType.Int32Array:
+    case OmDataType.Uint32Array:
+    case OmDataType.FloatArray:
+      return 4;
+    case OmDataType.Int64Array:
+    case OmDataType.Uint64Array:
+    case OmDataType.DoubleArray:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+// Bytes per element in compressed form
+export function bytesPerElementCompressed(dataType: OmDataType, compression: OmCompression): number {
+  switch (compression) {
+    case OmCompression.PforDelta2dInt16:
+    case OmCompression.PforDelta2dInt16Logarithmic:
+      return 2; // float → int16
+    case OmCompression.FpxXor2d:
+    case OmCompression.PforDelta2d:
+      return bytesPerElement(dataType);
+    default:
+      return bytesPerElement(dataType);
+  }
+}

--- a/packages/file-format/src/delta2d.ts
+++ b/packages/file-format/src/delta2d.ts
@@ -1,0 +1,80 @@
+// delta2d.ts — 2D delta / XOR filter for OM file format
+//
+// After TurboPFor decompression, these filters reconstruct the original values
+// by reversing the 2D delta coding applied during compression.
+//
+// Layout: data[d0 * length1 + d1] where d0 is the "slow" (row) dimension
+// and d1 is the "fast" (column) dimension.
+// The delta is applied along d0 (rows), comparing each row to the previous.
+
+/** In-place 2D delta decode for Int8/Uint8 buffers. */
+export function delta2dDecode8(length0: number, length1: number, buf: Int8Array | Uint8Array): void {
+  for (let d0 = 1; d0 < length0; d0++) {
+    const rowOff = d0 * length1;
+    const prevOff = (d0 - 1) * length1;
+    for (let d1 = 0; d1 < length1; d1++) {
+      buf[rowOff + d1] = (buf[rowOff + d1] + buf[prevOff + d1]) & 0xff;
+    }
+  }
+}
+
+/** In-place 2D delta decode for Int16/Uint16 buffers. */
+export function delta2dDecode16(length0: number, length1: number, buf: Int16Array | Uint16Array): void {
+  for (let d0 = 1; d0 < length0; d0++) {
+    const rowOff = d0 * length1;
+    const prevOff = (d0 - 1) * length1;
+    for (let d1 = 0; d1 < length1; d1++) {
+      buf[rowOff + d1] = (buf[rowOff + d1] + buf[prevOff + d1]) & 0xffff;
+    }
+  }
+}
+
+/** In-place 2D delta decode for Int32/Uint32 buffers. */
+export function delta2dDecode32(length0: number, length1: number, buf: Int32Array | Uint32Array): void {
+  for (let d0 = 1; d0 < length0; d0++) {
+    const rowOff = d0 * length1;
+    const prevOff = (d0 - 1) * length1;
+    for (let d1 = 0; d1 < length1; d1++) {
+      buf[rowOff + d1] = (buf[rowOff + d1] + buf[prevOff + d1]) >>> 0;
+    }
+  }
+}
+
+/** In-place 2D delta decode for Int64/Uint64 buffers. */
+export function delta2dDecode64(length0: number, length1: number, buf: BigInt64Array | BigUint64Array): void {
+  for (let d0 = 1; d0 < length0; d0++) {
+    const rowOff = d0 * length1;
+    const prevOff = (d0 - 1) * length1;
+    for (let d1 = 0; d1 < length1; d1++) {
+      buf[rowOff + d1] = buf[rowOff + d1] + buf[prevOff + d1];
+    }
+  }
+}
+
+/**
+ * In-place 2D XOR decode for Float32 buffers (used with COMPRESSION_FPX_XOR2D).
+ * Operates on the float bits as uint32.
+ */
+export function delta2dDecodeXor(length0: number, length1: number, buf: Uint32Array): void {
+  for (let d0 = 1; d0 < length0; d0++) {
+    const rowOff = d0 * length1;
+    const prevOff = (d0 - 1) * length1;
+    for (let d1 = 0; d1 < length1; d1++) {
+      buf[rowOff + d1] = (buf[rowOff + d1] ^ buf[prevOff + d1]) >>> 0;
+    }
+  }
+}
+
+/**
+ * In-place 2D XOR decode for Float64 buffers (used with COMPRESSION_FPX_XOR2D for doubles).
+ * Operates on the double bits as uint64 (via BigUint64Array view).
+ */
+export function delta2dDecodeXorDouble(length0: number, length1: number, buf: BigUint64Array): void {
+  for (let d0 = 1; d0 < length0; d0++) {
+    const rowOff = d0 * length1;
+    const prevOff = (d0 - 1) * length1;
+    for (let d1 = 0; d1 < length1; d1++) {
+      buf[rowOff + d1] = buf[rowOff + d1] ^ buf[prevOff + d1];
+    }
+  }
+}

--- a/packages/file-format/src/fp.ts
+++ b/packages/file-format/src/fp.ts
@@ -1,0 +1,102 @@
+// fp.ts — Floating point XOR compression (fpxdec32, fpxdec64)
+//
+// Algorithm: TurboFloat XOR (from TurboPFor library)
+// For each block of VSIZE=128 values:
+//   1. Read 1 byte b = leading-zero shift count
+//   2. Decode VSIZE values using p4dec128v (vertical PFor, pure unsigned, no delta)
+//   3. For each value: output = reverseBits(packed) >> b ^ prev; prev = output
+// For the remaining < VSIZE values: same but using scalar horizontal p4dec.
+//
+// The output uint32/uint64 bits are the float32/float64 bit patterns.
+
+import { p4dec128v32_block, p4dec64_block } from "./turbopfor.js";
+
+const VSIZE = 128;
+
+// Reverse bits of a 32-bit integer
+function reverseBits32(x: number): number {
+  x = ((x & 0xaaaaaaaa) >>> 1) | ((x & 0x55555555) << 1);
+  x = ((x & 0xcccccccc) >>> 2) | ((x & 0x33333333) << 2);
+  x = ((x & 0xf0f0f0f0) >>> 4) | ((x & 0x0f0f0f0f) << 4);
+  x = ((x & 0xff00ff00) >>> 8) | ((x & 0x00ff00ff) << 8);
+  return ((x >>> 16) | (x << 16)) >>> 0;
+}
+
+// Reverse bits of a 64-bit BigInt via two 32-bit halves
+function reverseBits64(x: bigint): bigint {
+  const lo = reverseBits32(Number(x & 0xffffffffn));
+  const hi = reverseBits32(Number((x >> 32n) & 0xffffffffn));
+  return (BigInt(lo) << 32n) | BigInt(hi >>> 0);
+}
+
+const _fpTmp32 = new Uint32Array(VSIZE + 8);
+const _fpTmp64 = new BigUint64Array(VSIZE + 8);
+
+/**
+ * Decode fpxdec32 compressed bytes into dst (uint32 bit patterns).
+ * Call with start=0. Returns bytes consumed.
+ */
+export function fpxdec32(src: Uint8Array, srcOff: number, n: number, dst: Uint32Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+  let prev = 0;
+  let op = dstOff;
+  let remaining = n;
+
+  while (remaining >= VSIZE) {
+    const b = src[ip++];
+    ip += p4dec128v32_block(src, ip, VSIZE, _fpTmp32, 0);
+    for (let i = 0; i < VSIZE; i++) {
+      const u = reverseBits32(_fpTmp32[i]) >>> b;
+      const out = (u ^ prev) >>> 0;
+      dst[op + i] = out;
+      prev = out;
+    }
+    op += VSIZE;
+    remaining -= VSIZE;
+  }
+
+  if (remaining > 0) {
+    const b = src[ip++];
+    ip += p4dec128v32_block(src, ip, remaining, _fpTmp32, 0);
+    for (let i = 0; i < remaining; i++) {
+      const u = reverseBits32(_fpTmp32[i]) >>> b;
+      const out = (u ^ prev) >>> 0;
+      dst[op + i] = out;
+      prev = out;
+    }
+    op += remaining;
+    remaining = 0;
+  }
+
+  return ip - srcOff;
+}
+
+/**
+ * Decode fpxdec64 compressed bytes into dst (uint64 bit patterns, BigInt).
+ * Call with start=0n. Returns bytes consumed.
+ */
+export function fpxdec64(src: Uint8Array, srcOff: number, n: number, dst: BigUint64Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+  let prev = 0n;
+  let op = dstOff;
+  let remaining = n;
+
+  while (remaining > 0) {
+    const count = Math.min(remaining, VSIZE);
+    const b = src[ip++];
+    ip += p4dec64_block(src, ip, count, _fpTmp64, 0);
+    const bBig = BigInt(b);
+    for (let i = 0; i < count; i++) {
+      const u = reverseBits64(_fpTmp64[i]) >> bBig;
+      const out = u ^ prev;
+      dst[op + i] = out;
+      prev = out;
+    }
+    op += count;
+    remaining -= count;
+  }
+
+  return ip - srcOff;
+}

--- a/packages/file-format/src/fp.ts
+++ b/packages/file-format/src/fp.ts
@@ -65,8 +65,6 @@ export function fpxdec32(src: Uint8Array, srcOff: number, n: number, dst: Uint32
       dst[op + i] = out;
       prev = out;
     }
-    op += remaining;
-    remaining = 0;
   }
 
   return ip - srcOff;

--- a/packages/file-format/src/index.ts
+++ b/packages/file-format/src/index.ts
@@ -1,0 +1,10 @@
+// index.ts — Public API of @openmeteo/file-format
+
+export * from "./constants.js";
+export * from "./vbx.js";
+export * from "./turbopfor.js";
+export * from "./delta2d.js";
+export * from "./fp.js";
+export * from "./om_file.js";
+export * from "./om_variable.js";
+export * from "./om_decoder.js";

--- a/packages/file-format/src/om_decoder.ts
+++ b/packages/file-format/src/om_decoder.ts
@@ -373,6 +373,9 @@ export function omNextDataRead(
 
     let readPos = chunkIndex - dataRead.indexRange.lowerBound - startOffset;
     if (!isOffset0 && (readPos + 1) * 8 > indexData.byteLength) {
+      console.error(
+        `[omNextDataRead V1] OutOfBoundRead: readPos=${readPos}, indexData.byteLength=${indexData.byteLength}, chunkIndex=${chunkIndex}, indexRange=[${dataRead.indexRange.lowerBound},${dataRead.indexRange.upperBound})`
+      );
       return { result: false, error: OmError.OutOfBoundRead };
     }
 
@@ -382,6 +385,9 @@ export function omNextDataRead(
     while (true) {
       readPos = dataRead.nextChunk.lowerBound - dataRead.indexRange.lowerBound - startOffset + 1;
       if ((readPos + 1) * 8 > indexData.byteLength) {
+        console.error(
+          `[omNextDataRead V1] OutOfBoundRead in loop: readPos=${readPos}, indexData.byteLength=${indexData.byteLength}`
+        );
         return { result: false, error: OmError.OutOfBoundRead };
       }
       const dataEndPos = Number(lutView.getBigUint64(readPos * 8, true));
@@ -429,6 +435,9 @@ export function omNextDataRead(
     const thisElemCount = omMin((lutChunk + 1) * LUT_CHUNK_COUNT, nChunks + 1) - lutChunk * LUT_CHUNK_COUNT;
     const start = lutChunk * lutChunkLength - lutOffset;
     if (start + lutChunkLength > indexData.byteLength || thisElemCount > LUT_CHUNK_COUNT) {
+      console.error(
+        `[omNextDataRead V3] OutOfBoundRead first LUT chunk: start=${start}, lutChunkLength=${lutChunkLength}, indexData.byteLength=${indexData.byteLength}, thisElemCount=${thisElemCount}, lutChunk=${lutChunk}, lutOffset=${lutOffset}`
+      );
       return { result: false, error: OmError.OutOfBoundRead };
     }
     p4nddec64(indexData, start, thisElemCount, uncompressedLut, 0);
@@ -444,6 +453,9 @@ export function omNextDataRead(
       const nextElemCount = omMin((nextLutChunk + 1) * LUT_CHUNK_COUNT, nChunks + 1) - nextLutChunk * LUT_CHUNK_COUNT;
       const start = nextLutChunk * lutChunkLength - lutOffset;
       if (start + lutChunkLength > indexData.byteLength || nextElemCount > LUT_CHUNK_COUNT) {
+        console.error(
+          `[omNextDataRead V3] OutOfBoundRead next LUT chunk: start=${start}, lutChunkLength=${lutChunkLength}, indexData.byteLength=${indexData.byteLength}, nextElemCount=${nextElemCount}`
+        );
         return { result: false, error: OmError.OutOfBoundRead };
       }
       p4nddec64(indexData, start, nextElemCount, uncompressedLut, 0);
@@ -924,11 +936,26 @@ export function omDecodeChunks(
 ): OmError {
   let pos = 0;
   for (let chunkNum = chunkRange.lowerBound; chunkNum < chunkRange.upperBound; chunkNum++) {
-    if (pos >= data.byteLength) return OmError.DeflatedSizeMismatch;
+    if (pos >= data.byteLength) {
+      console.error(
+        `[omDecodeChunks] pos=${pos} >= data.byteLength=${data.byteLength} at chunkNum=${chunkNum}, chunkRange=[${chunkRange.lowerBound},${chunkRange.upperBound})`
+      );
+      return OmError.DeflatedSizeMismatch;
+    }
     const consumed = _decodeChunk(decoder, chunkNum, data, pos, output, chunkBuf);
+    if (consumed === 0 && chunkRange.upperBound - chunkRange.lowerBound > 1) {
+      console.warn(
+        `[omDecodeChunks] chunkNum=${chunkNum} consumed 0 bytes (compression=${decoder.compression}, dataType=${decoder.dataType})`
+      );
+    }
     pos += consumed;
   }
-  if (pos !== data.byteLength) return OmError.DeflatedSizeMismatch;
+  if (pos !== data.byteLength) {
+    console.error(
+      `[omDecodeChunks] final pos=${pos} !== data.byteLength=${data.byteLength}, chunkRange=[${chunkRange.lowerBound},${chunkRange.upperBound}), compression=${decoder.compression}`
+    );
+    return OmError.DeflatedSizeMismatch;
+  }
   return OmError.Ok;
 }
 

--- a/packages/file-format/src/om_decoder.ts
+++ b/packages/file-format/src/om_decoder.ts
@@ -1,0 +1,970 @@
+// om_decoder.ts — OM file chunk decoder (pure TypeScript port of om_decoder.c)
+
+import { OmDataType, OmCompression, OmError, LUT_CHUNK_COUNT, OM_HEADER_V1_SIZE } from "./constants.js";
+import {
+  p4nzdec128v16,
+  p4nddec128v16,
+  p4nzdec128v32,
+  p4nddec128v32,
+  p4nzdec8,
+  p4nddec8,
+  p4nzdec64,
+  p4nddec64,
+} from "./turbopfor.js";
+import { fpxdec32, fpxdec64 } from "./fp.js";
+import {
+  delta2dDecode8,
+  delta2dDecode16,
+  delta2dDecode32,
+  delta2dDecode64,
+  delta2dDecodeXor,
+  delta2dDecodeXorDouble,
+} from "./delta2d.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function divRoundUp(a: number, b: number): number {
+  return Math.ceil(a / b);
+}
+function omMin(a: number, b: number): number {
+  return a < b ? a : b;
+}
+function omMax(a: number, b: number): number {
+  return a > b ? a : b;
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A contiguous range [lowerBound, upperBound). */
+export interface OmRange {
+  lowerBound: number;
+  upperBound: number;
+}
+
+/** State for one LUT (index) read operation. */
+export interface OmIndexRead {
+  /** File byte offset to read. */
+  offset: number;
+  /** Byte count to read. */
+  count: number;
+  /** Which chunk indices are covered by this index read. */
+  indexRange: OmRange;
+  /** Chunk range the caller should process after reading. */
+  chunkIndex: OmRange;
+  /** Internal: next chunk to continue from. */
+  nextChunk: OmRange;
+}
+
+/** State for one compressed-data read + decode operation. */
+export interface OmDataRead {
+  /** File byte offset to read. */
+  offset: number;
+  /** Byte count to read. */
+  count: number;
+  /** Which chunk indices are covered by this data read. */
+  indexRange: OmRange;
+  /** Chunk range to decode. */
+  chunkIndex: OmRange;
+  /** Internal: next chunk to continue from. */
+  nextChunk: OmRange;
+}
+
+/** Immutable decoder configuration, created by omDecoderInit(). */
+export interface OmDecoder {
+  scaleFactor: number;
+  addOffset: number;
+  dimensions: number[];
+  dimensionsCount: number;
+  chunks: number[];
+  readOffset: number[];
+  readCount: number[];
+  cubeOffset: number[] | null;
+  cubeDimensions: number[] | null;
+  lutChunkLength: number; // 0 = legacy V1; >1 = V3 compressed
+  lutStart: number; // file byte offset of LUT start
+  ioSizeMerge: number;
+  ioSizeMax: number;
+  numberOfChunks: number;
+  dataType: OmDataType;
+  compression: OmCompression;
+  bytesPerElement: number;
+  bytesPerElementCompressed: number;
+}
+
+/** Variable metadata needed to construct a decoder. */
+export interface OmDecoderVariable {
+  scaleFactor: number;
+  addOffset: number;
+  dataType: OmDataType;
+  compression: OmCompression;
+  dimensions: number[];
+  chunks: number[];
+  /** V3 array LUT size in bytes (0 for legacy). */
+  lutSize: number;
+  /** V3 array LUT start offset in file (40 for legacy). */
+  lutOffset: number;
+  /** True if this is a legacy V1/V2 file header. */
+  isLegacy: boolean;
+}
+
+// ─── Decoder init ─────────────────────────────────────────────────────────────
+
+/**
+ * Initialise the decoder state.
+ * Returns an OmDecoder on success, or an OmError code on failure.
+ */
+export function omDecoderInit(
+  variable: OmDecoderVariable,
+  dimensionCount: number,
+  readOffset: number[],
+  readCount: number[],
+  cubeOffset: number[] | null,
+  cubeDimensions: number[] | null,
+  ioSizeMerge: number,
+  ioSizeMax: number
+): OmDecoder | OmError {
+  const { scaleFactor, addOffset, dataType, compression, dimensions, chunks } = variable;
+
+  let lutSize = variable.lutSize;
+  let lutStart = variable.lutOffset;
+  let lutChunkLength = variable.isLegacy ? 0 : 1;
+
+  if (variable.isLegacy) {
+    lutStart = OM_HEADER_V1_SIZE;
+    lutSize = 0;
+  }
+
+  // Validate and compute total chunk count
+  let nChunks = 1;
+  for (let i = 0; i < dimensionCount; i++) {
+    if (dimensions[i] === 0) return OmError.InvalidDimensions;
+    if (chunks[i] === 0 || chunks[i] > dimensions[i]) return OmError.InvalidChunkDimensions;
+    if (readOffset[i] >= dimensions[i]) return OmError.InvalidReadOffset;
+    if (readCount[i] > dimensions[i] || readOffset[i] + readCount[i] > dimensions[i]) return OmError.InvalidReadCount;
+
+    const cubeOff = cubeOffset == null ? 0 : cubeOffset[i];
+    const cubeDim = cubeDimensions == null ? readCount[i] : cubeDimensions[i];
+    if (cubeOff + readCount[i] > cubeDim) return OmError.InvalidCubeOffset;
+
+    nChunks *= divRoundUp(dimensions[i], chunks[i]);
+  }
+
+  if (lutChunkLength > 0) {
+    const nLutChunks = divRoundUp(nChunks + 1, LUT_CHUNK_COUNT);
+    lutChunkLength = nLutChunks > 0 ? Math.floor(lutSize / nLutChunks) : 0;
+  }
+
+  const bpe = bytesPerElement(dataType);
+  const bpec = bytesPerElementCompressed(dataType, compression);
+  if (bpe === 0 || bpec === 0) return OmError.InvalidDataType;
+
+  return {
+    scaleFactor,
+    addOffset,
+    dimensions,
+    dimensionsCount: dimensionCount,
+    chunks,
+    readOffset,
+    readCount,
+    cubeOffset,
+    cubeDimensions,
+    lutChunkLength,
+    lutStart,
+    ioSizeMerge,
+    ioSizeMax,
+    numberOfChunks: nChunks,
+    dataType,
+    compression,
+    bytesPerElement: bpe,
+    bytesPerElementCompressed: bpec,
+  };
+}
+
+/** Bytes of chunk buffer needed for one chunk. */
+export function omDecoderReadBufferSize(decoder: OmDecoder): number {
+  let len = 1;
+  for (let i = 0; i < decoder.dimensionsCount; i++) len *= decoder.chunks[i];
+  return len * decoder.bytesPerElement;
+}
+
+// ─── Index read iteration ─────────────────────────────────────────────────────
+
+/** Initialise the OmIndexRead state. Call before iterating with omNextIndexRead(). */
+export function omInitIndexRead(decoder: OmDecoder): OmIndexRead {
+  let chunkStart = 0;
+  let chunkEnd = 1;
+
+  for (let i = 0; i < decoder.dimensionsCount; i++) {
+    const dim = decoder.dimensions[i];
+    const chunk = decoder.chunks[i];
+    const ro = decoder.readOffset[i];
+    const rc = decoder.readCount[i];
+
+    const chunksLower = Math.floor(ro / chunk);
+    const chunksUpper = divRoundUp(ro + rc, chunk);
+    const chunksCount = chunksUpper - chunksLower;
+    const nChunksInDim = divRoundUp(dim, chunk);
+
+    chunkStart = chunkStart * nChunksInDim + chunksLower;
+    if (rc === dim) {
+      chunkEnd = chunkEnd * nChunksInDim;
+    } else {
+      chunkEnd = chunkStart + chunksCount;
+    }
+  }
+
+  return {
+    offset: 0,
+    count: 0,
+    indexRange: { lowerBound: 0, upperBound: 0 },
+    chunkIndex: { lowerBound: 0, upperBound: 0 },
+    nextChunk: { lowerBound: chunkStart, upperBound: chunkEnd },
+  };
+}
+
+/** Initialise OmDataRead from an OmIndexRead state. */
+export function omInitDataRead(indexRead: OmIndexRead): OmDataRead {
+  return {
+    offset: 0,
+    count: 0,
+    indexRange: { ...indexRead.indexRange },
+    chunkIndex: { lowerBound: 0, upperBound: 0 },
+    nextChunk: { ...indexRead.chunkIndex },
+  };
+}
+
+// ─── Internal: advance chunk position ────────────────────────────────────────
+
+function _nextChunkPosition(decoder: OmDecoder, chunkIndex: OmRange): boolean {
+  let rollingMultiply = 1;
+  let linearReadCount = 1;
+  let linearRead = true;
+  const n = decoder.dimensionsCount;
+
+  for (let iForward = 0; iForward < n; iForward++) {
+    const i = n - iForward - 1;
+    const dim = decoder.dimensions[i];
+    const chunk = decoder.chunks[i];
+    const ro = decoder.readOffset[i];
+    const rc = decoder.readCount[i];
+
+    const nChunksInDim = divRoundUp(dim, chunk);
+    const chunksLower = Math.floor(ro / chunk);
+    const chunksUpper = divRoundUp(ro + rc, chunk);
+    const chunksCount = chunksUpper - chunksLower;
+
+    chunkIndex.lowerBound += rollingMultiply;
+
+    if (i === n - 1 && dim !== rc) {
+      linearReadCount = chunksCount;
+      linearRead = false;
+    }
+    if (linearRead && dim === rc) {
+      linearReadCount *= nChunksInDim;
+    } else {
+      linearRead = false;
+    }
+
+    const c0 = Math.floor(chunkIndex.lowerBound / rollingMultiply) % nChunksInDim;
+
+    if (c0 !== chunksUpper && c0 !== 0) {
+      break;
+    }
+
+    chunkIndex.lowerBound -= chunksCount * rollingMultiply;
+    rollingMultiply *= nChunksInDim;
+
+    if (i === 0) {
+      chunkIndex.upperBound = chunkIndex.lowerBound;
+      return false;
+    }
+  }
+
+  chunkIndex.upperBound = chunkIndex.lowerBound + linearReadCount;
+  return true;
+}
+
+// ─── Next index (LUT) read ───────────────────────────────────────────────────
+
+/**
+ * Advance the index read state to the next batch.
+ * Returns true if there is work to do (index_read.offset/count have been set).
+ */
+export function omNextIndexRead(decoder: OmDecoder, indexRead: OmIndexRead): boolean {
+  if (indexRead.nextChunk.lowerBound >= indexRead.nextChunk.upperBound) return false;
+
+  indexRead.chunkIndex = { ...indexRead.nextChunk };
+  indexRead.indexRange.lowerBound = indexRead.nextChunk.lowerBound;
+
+  let chunkIndex = indexRead.nextChunk.lowerBound;
+
+  const isV3LUT = decoder.lutChunkLength > 1;
+  const lutChunkElemCount = isV3LUT ? LUT_CHUNK_COUNT : 1;
+  const lutChunkLength = isV3LUT ? decoder.lutChunkLength : 8; // sizeof(uint64_t)
+  const ioSizeMax = decoder.ioSizeMax;
+
+  const alignOffset = isV3LUT || indexRead.indexRange.lowerBound === 0 ? 0 : 1;
+  const endAlignOffset = isV3LUT ? 1 : 0;
+
+  const readStart = Math.floor((indexRead.nextChunk.lowerBound - alignOffset) / lutChunkElemCount) * lutChunkLength;
+
+  while (true) {
+    const maxRead = Math.floor(ioSizeMax / lutChunkLength) * lutChunkElemCount;
+    const nextChunkCount = indexRead.nextChunk.upperBound - indexRead.nextChunk.lowerBound;
+    const nextIncrement = omMax(1, omMin(maxRead - 1, nextChunkCount - 1));
+
+    if (indexRead.nextChunk.lowerBound + nextIncrement >= indexRead.nextChunk.upperBound) {
+      if (!_nextChunkPosition(decoder, indexRead.nextChunk)) {
+        break;
+      }
+      const readEndNext =
+        divRoundUp(indexRead.nextChunk.lowerBound + endAlignOffset, lutChunkElemCount) * lutChunkLength;
+      const readStartNext = readEndNext - lutChunkLength;
+      const readEndPrevious = Math.floor(chunkIndex / lutChunkElemCount) * lutChunkLength;
+
+      if (readEndNext - readStart > ioSizeMax) break;
+      if (readStartNext - readEndPrevious > decoder.ioSizeMerge) break;
+    } else {
+      const readEndNext =
+        Math.floor((indexRead.nextChunk.lowerBound + nextIncrement + endAlignOffset) / lutChunkElemCount) *
+        lutChunkLength;
+      if (readEndNext - readStart > ioSizeMax) {
+        indexRead.nextChunk.lowerBound += 1;
+        break;
+      }
+      indexRead.nextChunk.lowerBound += nextIncrement;
+    }
+    chunkIndex = indexRead.nextChunk.lowerBound;
+  }
+
+  const readEnd = (Math.floor((chunkIndex + endAlignOffset) / lutChunkElemCount) + 1) * lutChunkLength;
+
+  indexRead.offset = decoder.lutStart + readStart;
+  indexRead.count = readEnd - readStart;
+  indexRead.indexRange.upperBound = chunkIndex + 1;
+  return true;
+}
+
+// ─── Next data read ──────────────────────────────────────────────────────────
+
+/**
+ * Decompress the LUT index data and determine the next data read range.
+ * Returns true if there is work to do.
+ */
+export function omNextDataRead(
+  decoder: OmDecoder,
+  dataRead: OmDataRead,
+  indexData: Uint8Array
+): { result: boolean; error: OmError } {
+  if (dataRead.nextChunk.lowerBound >= dataRead.nextChunk.upperBound) {
+    return { result: false, error: OmError.Ok };
+  }
+
+  let chunkIndex = dataRead.nextChunk.lowerBound;
+  dataRead.chunkIndex.lowerBound = chunkIndex;
+
+  const nChunks = decoder.numberOfChunks;
+
+  // ─── Legacy V1: LUT is a flat uint64 array ────────────────────────────────
+  if (decoder.lutChunkLength === 0) {
+    const isOffset0 = dataRead.indexRange.lowerBound === 0;
+    const startOffset = isOffset0 ? 1 : 0;
+    const lutView = new DataView(indexData.buffer, indexData.byteOffset, indexData.byteLength);
+
+    let readPos = chunkIndex - dataRead.indexRange.lowerBound - startOffset;
+    if (!isOffset0 && (readPos + 1) * 8 > indexData.byteLength) {
+      return { result: false, error: OmError.OutOfBoundRead };
+    }
+
+    const startPos = isOffset0 && chunkIndex === 0 ? 0 : Number(lutView.getBigUint64(readPos * 8, true));
+    let endPos = startPos;
+
+    while (true) {
+      readPos = dataRead.nextChunk.lowerBound - dataRead.indexRange.lowerBound - startOffset + 1;
+      if ((readPos + 1) * 8 > indexData.byteLength) {
+        return { result: false, error: OmError.OutOfBoundRead };
+      }
+      const dataEndPos = Number(lutView.getBigUint64(readPos * 8, true));
+
+      if (
+        startPos !== endPos &&
+        (dataEndPos - startPos > decoder.ioSizeMax || dataEndPos - endPos > decoder.ioSizeMerge)
+      ) {
+        break;
+      }
+      endPos = dataEndPos;
+      chunkIndex = dataRead.nextChunk.lowerBound;
+
+      if (dataRead.nextChunk.lowerBound + 1 >= dataRead.nextChunk.upperBound) {
+        if (!_nextChunkPosition(decoder, dataRead.nextChunk)) break;
+      } else {
+        dataRead.nextChunk.lowerBound += 1;
+      }
+
+      if (dataRead.nextChunk.lowerBound >= dataRead.indexRange.upperBound) {
+        dataRead.nextChunk.lowerBound = 0;
+        dataRead.nextChunk.upperBound = 0;
+        break;
+      }
+    }
+
+    // In legacy files, data follows the LUT immediately after the header
+    const dataStart = OM_HEADER_V1_SIZE + nChunks * 8;
+    dataRead.offset = startPos + dataStart;
+    dataRead.count = endPos - startPos;
+    dataRead.chunkIndex.upperBound = chunkIndex + 1;
+    return { result: true, error: OmError.Ok };
+  }
+
+  // ─── V3: LUT chunks are compressed with p4nddec64 ────────────────────────
+  const lutChunkLength = decoder.lutChunkLength;
+  const lutOffset = Math.floor(dataRead.indexRange.lowerBound / LUT_CHUNK_COUNT) * lutChunkLength;
+
+  const uncompressedLut = new BigUint64Array(LUT_CHUNK_COUNT);
+
+  let lutChunk = Math.floor(chunkIndex / LUT_CHUNK_COUNT);
+
+  // Decompress first LUT chunk
+  {
+    const thisElemCount = omMin((lutChunk + 1) * LUT_CHUNK_COUNT, nChunks + 1) - lutChunk * LUT_CHUNK_COUNT;
+    const start = lutChunk * lutChunkLength - lutOffset;
+    if (start + lutChunkLength > indexData.byteLength || thisElemCount > LUT_CHUNK_COUNT) {
+      return { result: false, error: OmError.OutOfBoundRead };
+    }
+    p4nddec64(indexData, start, thisElemCount, uncompressedLut, 0);
+  }
+
+  const startPos = Number(uncompressedLut[chunkIndex % LUT_CHUNK_COUNT]);
+  let endPos = startPos;
+
+  while (true) {
+    const nextLutChunk = Math.floor((dataRead.nextChunk.lowerBound + 1) / LUT_CHUNK_COUNT);
+
+    if (nextLutChunk !== lutChunk) {
+      const nextElemCount = omMin((nextLutChunk + 1) * LUT_CHUNK_COUNT, nChunks + 1) - nextLutChunk * LUT_CHUNK_COUNT;
+      const start = nextLutChunk * lutChunkLength - lutOffset;
+      if (start + lutChunkLength > indexData.byteLength || nextElemCount > LUT_CHUNK_COUNT) {
+        return { result: false, error: OmError.OutOfBoundRead };
+      }
+      p4nddec64(indexData, start, nextElemCount, uncompressedLut, 0);
+      lutChunk = nextLutChunk;
+    }
+
+    const dataEndPos = Number(uncompressedLut[(dataRead.nextChunk.lowerBound + 1) % LUT_CHUNK_COUNT]);
+
+    if (
+      startPos !== endPos &&
+      (dataEndPos - startPos > decoder.ioSizeMax || dataEndPos - endPos > decoder.ioSizeMerge)
+    ) {
+      break;
+    }
+    endPos = dataEndPos;
+    chunkIndex = dataRead.nextChunk.lowerBound;
+
+    if (chunkIndex + 1 >= dataRead.nextChunk.upperBound) {
+      if (!_nextChunkPosition(decoder, dataRead.nextChunk)) break;
+    } else {
+      dataRead.nextChunk.lowerBound += 1;
+    }
+
+    if (dataRead.nextChunk.lowerBound >= dataRead.indexRange.upperBound) {
+      dataRead.nextChunk.lowerBound = 0;
+      dataRead.nextChunk.upperBound = 0;
+      break;
+    }
+  }
+
+  dataRead.offset = startPos;
+  dataRead.count = endPos - startPos;
+  dataRead.chunkIndex.upperBound = chunkIndex + 1;
+  return { result: true, error: OmError.Ok };
+}
+
+// ─── Decompression helpers ───────────────────────────────────────────────────
+
+/** Decompress one chunk's worth of data. Returns bytes consumed. */
+function omDecodeDecompress(
+  dataType: OmDataType,
+  compression: OmCompression,
+  src: Uint8Array,
+  srcOff: number,
+  count: number,
+  chunkBuf: Uint8Array
+): number {
+  switch (compression) {
+    case OmCompression.PforDelta2dInt16:
+    case OmCompression.PforDelta2dInt16Logarithmic: {
+      const out = new Uint16Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+      return p4nzdec128v16(src, srcOff, count, out, 0);
+    }
+    case OmCompression.FpxXor2d:
+      if (dataType === OmDataType.FloatArray) {
+        const out = new Uint32Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+        return fpxdec32(src, srcOff, count, out, 0);
+      } else {
+        const out = new BigUint64Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+        return fpxdec64(src, srcOff, count, out, 0);
+      }
+    case OmCompression.PforDelta2d:
+      switch (dataType) {
+        case OmDataType.Int8Array: {
+          const out = new Uint8Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nzdec8(src, srcOff, count, out, 0);
+        }
+        case OmDataType.Uint8Array: {
+          const out = new Uint8Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nddec8(src, srcOff, count, out, 0);
+        }
+        case OmDataType.Int16Array: {
+          const out = new Uint16Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nzdec128v16(src, srcOff, count, out, 0);
+        }
+        case OmDataType.Uint16Array: {
+          const out = new Uint16Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nddec128v16(src, srcOff, count, out, 0);
+        }
+        case OmDataType.Int32Array:
+        case OmDataType.FloatArray: {
+          const out = new Uint32Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nzdec128v32(src, srcOff, count, out, 0);
+        }
+        case OmDataType.Uint32Array: {
+          const out = new Uint32Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nddec128v32(src, srcOff, count, out, 0);
+        }
+        case OmDataType.Int64Array:
+        case OmDataType.DoubleArray: {
+          const out = new BigUint64Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nzdec64(src, srcOff, count, out, 0);
+        }
+        case OmDataType.Uint64Array: {
+          const out = new BigUint64Array(chunkBuf.buffer, chunkBuf.byteOffset, count);
+          return p4nddec64(src, srcOff, count, out, 0);
+        }
+        default:
+          return 0;
+      }
+    case OmCompression.None:
+    default:
+      return 0;
+  }
+}
+
+/** Apply 2D delta/XOR filter in-place on the chunk buffer. */
+function omDecodeFilter(
+  dataType: OmDataType,
+  compression: OmCompression,
+  chunkBuf: Uint8Array,
+  lengthInChunk: number,
+  lengthLast: number
+): void {
+  const width = lengthInChunk / lengthLast;
+  switch (compression) {
+    case OmCompression.PforDelta2dInt16:
+    case OmCompression.PforDelta2dInt16Logarithmic: {
+      const view = new Int16Array(chunkBuf.buffer, chunkBuf.byteOffset, lengthInChunk);
+      delta2dDecode16(width, lengthLast, view);
+      break;
+    }
+    case OmCompression.FpxXor2d:
+      if (dataType === OmDataType.FloatArray) {
+        const view = new Uint32Array(chunkBuf.buffer, chunkBuf.byteOffset, lengthInChunk);
+        delta2dDecodeXor(width, lengthLast, view);
+      } else {
+        const view = new BigUint64Array(chunkBuf.buffer, chunkBuf.byteOffset, lengthInChunk);
+        delta2dDecodeXorDouble(width, lengthLast, view);
+      }
+      break;
+    case OmCompression.PforDelta2d:
+      switch (dataType) {
+        case OmDataType.Int8Array:
+        case OmDataType.Uint8Array: {
+          const view = new Int8Array(chunkBuf.buffer, chunkBuf.byteOffset, lengthInChunk);
+          delta2dDecode8(width, lengthLast, view);
+          break;
+        }
+        case OmDataType.Int16Array:
+        case OmDataType.Uint16Array: {
+          const view = new Int16Array(chunkBuf.buffer, chunkBuf.byteOffset, lengthInChunk);
+          delta2dDecode16(width, lengthLast, view);
+          break;
+        }
+        case OmDataType.Int32Array:
+        case OmDataType.Uint32Array:
+        case OmDataType.FloatArray: {
+          const view = new Int32Array(chunkBuf.buffer, chunkBuf.byteOffset, lengthInChunk);
+          delta2dDecode32(width, lengthLast, view);
+          break;
+        }
+        case OmDataType.Int64Array:
+        case OmDataType.Uint64Array:
+        case OmDataType.DoubleArray: {
+          const view = new BigInt64Array(chunkBuf.buffer, chunkBuf.byteOffset, lengthInChunk);
+          delta2dDecode64(width, lengthLast, view);
+          break;
+        }
+        default:
+          break;
+      }
+      break;
+    case OmCompression.None:
+    default:
+      break;
+  }
+}
+
+const INT16_MAX = 32767;
+const INT32_MAX = 2147483647;
+const INT64_MAX = 9223372036854775807n;
+
+/** Copy decoded values from chunkBuf (at element index `d`) to `output` (at element index `q`). */
+function omDecodeCopy(
+  dataType: OmDataType,
+  compression: OmCompression,
+  count: number,
+  scaleFactor: number,
+  addOffset: number,
+  chunkBuf: Uint8Array,
+  d: number, // element offset in chunkBuf
+  bytesPerElementCompressed: number,
+  output:
+    | Float32Array
+    | Float64Array
+    | Int8Array
+    | Uint8Array
+    | Int16Array
+    | Uint16Array
+    | Int32Array
+    | Uint32Array
+    | BigInt64Array
+    | BigUint64Array,
+  q: number // element offset in output
+): void {
+  switch (compression) {
+    case OmCompression.PforDelta2dInt16: {
+      const src = new Int16Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 2, count);
+      const dst = output as Float32Array;
+      for (let i = 0; i < count; i++) {
+        const v = src[i];
+        dst[q + i] = v === INT16_MAX ? NaN : v / scaleFactor - addOffset;
+      }
+      break;
+    }
+    case OmCompression.PforDelta2dInt16Logarithmic: {
+      const src = new Int16Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 2, count);
+      const dst = output as Float32Array;
+      for (let i = 0; i < count; i++) {
+        const v = src[i];
+        dst[q + i] = v === INT16_MAX ? NaN : Math.pow(10, v / scaleFactor) - 1;
+      }
+      break;
+    }
+    case OmCompression.FpxXor2d:
+      if (dataType === OmDataType.FloatArray) {
+        // Uint32 bits → Float32 (reinterpret cast via shared buffer)
+        const srcU32 = new Uint32Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 4, count);
+        const dstF32 = output as Float32Array;
+        // Fastest reinterpret: use a shared DataView
+        const tmp = new DataView(chunkBuf.buffer, chunkBuf.byteOffset + d * 4);
+        for (let i = 0; i < count; i++) {
+          dstF32[q + i] = tmp.getFloat32(i * 4, true);
+        }
+      } else {
+        // BigUint64 bits → Float64
+        const srcU64 = new BigUint64Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 8, count);
+        const dstF64 = output as Float64Array;
+        const tmp = new DataView(chunkBuf.buffer, chunkBuf.byteOffset + d * 8);
+        for (let i = 0; i < count; i++) {
+          dstF64[q + i] = tmp.getFloat64(i * 8, true);
+        }
+      }
+      break;
+    case OmCompression.PforDelta2d:
+      switch (dataType) {
+        case OmDataType.Int8Array:
+        case OmDataType.Uint8Array: {
+          const src = new Uint8Array(chunkBuf.buffer, chunkBuf.byteOffset + d, count);
+          const dst = output as Int8Array | Uint8Array;
+          for (let i = 0; i < count; i++) dst[q + i] = src[i];
+          break;
+        }
+        case OmDataType.Int16Array:
+        case OmDataType.Uint16Array: {
+          const src = new Uint16Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 2, count);
+          const dst = output as Int16Array | Uint16Array;
+          for (let i = 0; i < count; i++) dst[q + i] = src[i];
+          break;
+        }
+        case OmDataType.Int32Array:
+        case OmDataType.Uint32Array: {
+          const src = new Uint32Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 4, count);
+          const dst = output as Int32Array | Uint32Array;
+          for (let i = 0; i < count; i++) dst[q + i] = src[i];
+          break;
+        }
+        case OmDataType.FloatArray: {
+          // Int32 → Float32 with scale
+          const src = new Int32Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 4, count);
+          const dst = output as Float32Array;
+          for (let i = 0; i < count; i++) {
+            const v = src[i];
+            dst[q + i] = v === INT32_MAX ? NaN : v / scaleFactor - addOffset;
+          }
+          break;
+        }
+        case OmDataType.Int64Array:
+        case OmDataType.Uint64Array: {
+          const src = new BigUint64Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 8, count);
+          const dst = output as BigInt64Array | BigUint64Array;
+          for (let i = 0; i < count; i++) dst[q + i] = src[i];
+          break;
+        }
+        case OmDataType.DoubleArray: {
+          const src = new BigInt64Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 8, count);
+          const dst = output as Float64Array;
+          const sf = scaleFactor;
+          const ao = addOffset;
+          for (let i = 0; i < count; i++) {
+            const v = src[i];
+            dst[q + i] = v === BigInt(INT64_MAX) ? NaN : Number(v) / sf - ao;
+          }
+          break;
+        }
+        default:
+          break;
+      }
+      break;
+    case OmCompression.None:
+    default:
+      break;
+  }
+}
+
+// ─── Chunk decode ─────────────────────────────────────────────────────────────
+
+type OutputArray =
+  | Float32Array
+  | Float64Array
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | BigInt64Array
+  | BigUint64Array;
+
+/** Decode one chunk. Returns bytes consumed from `data`. */
+function _decodeChunk(
+  decoder: OmDecoder,
+  chunkIndex: number,
+  data: Uint8Array,
+  dataOff: number,
+  output: OutputArray,
+  chunkBuf: Uint8Array
+): number {
+  let rollingMultiply = 1;
+  let rollingMultiplyChunkLength = 1;
+  let rollingMultiplyTargetCube = 1;
+
+  let d = 0;
+  let q = 0;
+  let linearReadCount = 1;
+  let linearRead = true;
+  let lengthLast = 0;
+  let noData = false;
+
+  const n = decoder.dimensionsCount;
+
+  // First pass: compute d (chunk buffer offset), q (output offset), lengthInChunk
+  for (let iForward = 0; iForward < n; iForward++) {
+    const i = n - iForward - 1;
+    const dim = decoder.dimensions[i];
+    const chunk = decoder.chunks[i];
+    const ro = decoder.readOffset[i];
+    const rc = decoder.readCount[i];
+    const cubeOff = decoder.cubeOffset == null ? 0 : decoder.cubeOffset[i];
+    const cubeDim = decoder.cubeDimensions == null ? rc : decoder.cubeDimensions[i];
+
+    const nChunksInDim = divRoundUp(dim, chunk);
+    const c0 = Math.floor(chunkIndex / rollingMultiply) % nChunksInDim;
+    const chunkGlobalStart = c0 * chunk;
+    const chunkGlobalEnd = omMin((c0 + 1) * chunk, dim);
+    const length0 = chunkGlobalEnd - chunkGlobalStart;
+    const clampedGlobalStart = omMax(chunkGlobalStart, ro);
+    const clampedGlobalEnd = omMin(chunkGlobalEnd, ro + rc);
+    const clampedLocalStart = clampedGlobalStart - c0 * chunk;
+    const lengthRead = clampedGlobalEnd - clampedGlobalStart;
+
+    if (ro + rc <= chunkGlobalStart || ro >= chunkGlobalEnd) noData = true;
+
+    if (i === n - 1) lengthLast = length0;
+
+    const t0 = chunkGlobalStart - ro + clampedLocalStart;
+    const q0 = t0 + cubeOff;
+
+    d += rollingMultiplyChunkLength * clampedLocalStart;
+    q += rollingMultiplyTargetCube * q0;
+
+    if (i === n - 1 && !(lengthRead === length0 && rc === length0 && cubeDim === length0)) {
+      linearReadCount = lengthRead;
+      linearRead = false;
+    }
+    if (linearRead && lengthRead === length0 && rc === length0 && cubeDim === length0) {
+      linearReadCount *= length0;
+    } else {
+      linearRead = false;
+    }
+
+    rollingMultiply *= nChunksInDim;
+    rollingMultiplyTargetCube *= cubeDim;
+    rollingMultiplyChunkLength *= length0;
+  }
+
+  const lengthInChunk = rollingMultiplyChunkLength;
+
+  // Decompress
+  const uncompressedBytes = omDecodeDecompress(
+    decoder.dataType,
+    decoder.compression,
+    data,
+    dataOff,
+    lengthInChunk,
+    chunkBuf
+  );
+
+  if (noData) return uncompressedBytes;
+
+  // 2D filter
+  omDecodeFilter(decoder.dataType, decoder.compression, chunkBuf, lengthInChunk, lengthLast);
+
+  // Scatter-copy loop
+  while (true) {
+    omDecodeCopy(
+      decoder.dataType,
+      decoder.compression,
+      linearReadCount,
+      decoder.scaleFactor,
+      decoder.addOffset,
+      chunkBuf,
+      d,
+      decoder.bytesPerElementCompressed,
+      output,
+      q
+    );
+
+    q += linearReadCount - 1;
+    d += linearReadCount - 1;
+
+    // Re-init for next run
+    rollingMultiply = 1;
+    rollingMultiplyTargetCube = 1;
+    rollingMultiplyChunkLength = 1;
+    linearReadCount = 1;
+    linearRead = true;
+
+    for (let iForward = 0; iForward < n; iForward++) {
+      const i = n - iForward - 1;
+      const dim = decoder.dimensions[i];
+      const chunk = decoder.chunks[i];
+      const ro = decoder.readOffset[i];
+      const rc = decoder.readCount[i];
+      const cubeDim = decoder.cubeDimensions == null ? rc : decoder.cubeDimensions[i];
+
+      const nChunksInDim = divRoundUp(dim, chunk);
+      const c0 = Math.floor(chunkIndex / rollingMultiply) % nChunksInDim;
+      const chunkGlobalStart = c0 * chunk;
+      const chunkGlobalEnd = omMin((c0 + 1) * chunk, dim);
+      const length0 = chunkGlobalEnd - chunkGlobalStart;
+      const clampedGlobalStart = omMax(chunkGlobalStart, ro);
+      const clampedGlobalEnd = omMin(chunkGlobalEnd, ro + rc);
+      const clampedLocalEnd = clampedGlobalEnd - chunkGlobalStart;
+      const lengthRead = clampedGlobalEnd - clampedGlobalStart;
+
+      d += rollingMultiplyChunkLength;
+      q += rollingMultiplyTargetCube;
+
+      if (i === n - 1 && !(lengthRead === length0 && rc === length0 && cubeDim === length0)) {
+        linearReadCount = lengthRead;
+        linearRead = false;
+      }
+      if (linearRead && lengthRead === length0 && rc === length0 && cubeDim === length0) {
+        linearReadCount *= length0;
+      } else {
+        linearRead = false;
+      }
+
+      const d0 = Math.floor(d / rollingMultiplyChunkLength) % length0;
+      if (d0 !== clampedLocalEnd && d0 !== 0) break;
+
+      d -= lengthRead * rollingMultiplyChunkLength;
+      q -= lengthRead * rollingMultiplyTargetCube;
+
+      rollingMultiply *= nChunksInDim;
+      rollingMultiplyTargetCube *= cubeDim;
+      rollingMultiplyChunkLength *= length0;
+
+      if (i === 0) return uncompressedBytes;
+    }
+  }
+}
+
+/**
+ * Decode all chunks in the given range.
+ * `data` is the compressed data read from the file (at `dataRead.offset`).
+ * `output` is the destination array (already allocated to the full read shape).
+ * `chunkBuf` is a scratch buffer; allocate it with omDecoderReadBufferSize().
+ */
+export function omDecodeChunks(
+  decoder: OmDecoder,
+  chunkRange: OmRange,
+  data: Uint8Array,
+  output: OutputArray,
+  chunkBuf: Uint8Array
+): OmError {
+  let pos = 0;
+  for (let chunkNum = chunkRange.lowerBound; chunkNum < chunkRange.upperBound; chunkNum++) {
+    if (pos >= data.byteLength) return OmError.DeflatedSizeMismatch;
+    const consumed = _decodeChunk(decoder, chunkNum, data, pos, output, chunkBuf);
+    pos += consumed;
+  }
+  if (pos !== data.byteLength) return OmError.DeflatedSizeMismatch;
+  return OmError.Ok;
+}
+
+// ─── Byte size helpers (duplicated from constants.ts to avoid circular) ──────
+
+function bytesPerElement(dataType: OmDataType): number {
+  switch (dataType) {
+    case OmDataType.Int8Array:
+    case OmDataType.Uint8Array:
+      return 1;
+    case OmDataType.Int16Array:
+    case OmDataType.Uint16Array:
+      return 2;
+    case OmDataType.Int32Array:
+    case OmDataType.Uint32Array:
+    case OmDataType.FloatArray:
+      return 4;
+    case OmDataType.Int64Array:
+    case OmDataType.Uint64Array:
+    case OmDataType.DoubleArray:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+function bytesPerElementCompressed(dataType: OmDataType, compression: OmCompression): number {
+  switch (compression) {
+    case OmCompression.PforDelta2dInt16:
+    case OmCompression.PforDelta2dInt16Logarithmic:
+      return 2;
+    case OmCompression.FpxXor2d:
+    case OmCompression.PforDelta2d:
+    case OmCompression.None:
+      return bytesPerElement(dataType);
+    default:
+      return bytesPerElement(dataType);
+  }
+}

--- a/packages/file-format/src/om_decoder.ts
+++ b/packages/file-format/src/om_decoder.ts
@@ -674,7 +674,6 @@ function omDecodeCopy(
     case OmCompression.FpxXor2d:
       if (dataType === OmDataType.FloatArray) {
         // Uint32 bits → Float32 (reinterpret cast via shared buffer)
-        const srcU32 = new Uint32Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 4, count);
         const dstF32 = output as Float32Array;
         // Fastest reinterpret: use a shared DataView
         const tmp = new DataView(chunkBuf.buffer, chunkBuf.byteOffset + d * 4);
@@ -683,7 +682,6 @@ function omDecodeCopy(
         }
       } else {
         // BigUint64 bits → Float64
-        const srcU64 = new BigUint64Array(chunkBuf.buffer, chunkBuf.byteOffset + d * 8, count);
         const dstF64 = output as Float64Array;
         const tmp = new DataView(chunkBuf.buffer, chunkBuf.byteOffset + d * 8);
         for (let i = 0; i < count; i++) {

--- a/packages/file-format/src/om_file.ts
+++ b/packages/file-format/src/om_file.ts
@@ -1,0 +1,48 @@
+// om_file.ts — OM file header and trailer parsing
+
+import { OmHeaderType, OM_HEADER_V1_SIZE, OM_TRAILER_SIZE } from "./constants.js";
+
+/**
+ * Check the type of an OM file header.
+ * `data` must be at least OM_HEADER_V1_SIZE (40) bytes for legacy files,
+ * or OM_TRAILER_SIZE (24) bytes for V3 trailer detection.
+ *
+ * For initial detection, pass the first few bytes. Returns:
+ * - OmHeaderType.Invalid: not an OM file
+ * - OmHeaderType.Legacy: version 1 or 2 header (use om_header_size())
+ * - OmHeaderType.ReadTrailer: version 3, must read trailer from end of file
+ */
+export function omHeaderType(data: Uint8Array): OmHeaderType {
+  if (data.length < 3) return OmHeaderType.Invalid;
+  if (data[0] !== 0x4f || data[1] !== 0x4d) return OmHeaderType.Invalid; // 'O','M'
+  const version = data[2];
+  if (version === 0 || version > 3) return OmHeaderType.Invalid;
+  if (version === 3) return OmHeaderType.ReadTrailer;
+  return OmHeaderType.Legacy; // version 1 or 2
+}
+
+/** Size of the V1/V2 legacy header (OmHeaderV1_t struct = 40 bytes). */
+export function omHeaderSize(): number {
+  return OM_HEADER_V1_SIZE;
+}
+
+/** Size of the V3 trailer (OmTrailer_t struct = 24 bytes). */
+export function omTrailerSize(): number {
+  return OM_TRAILER_SIZE;
+}
+
+/**
+ * Parse the V3 trailer bytes. Returns { offset, size } of the root variable,
+ * or null if the trailer is invalid.
+ * `trailerData` must be exactly OM_TRAILER_SIZE (24) bytes.
+ */
+export function omTrailerRead(trailerData: Uint8Array): { offset: bigint; size: bigint } | null {
+  if (trailerData.length < OM_TRAILER_SIZE) return null;
+  // Trailer: uint8 magic1='O', uint8 magic2='M', uint8 version=3, uint8[5] padding,
+  //           uint64_le offset, uint64_le size
+  if (trailerData[0] !== 0x4f || trailerData[1] !== 0x4d || trailerData[2] !== 3) return null;
+  const view = new DataView(trailerData.buffer, trailerData.byteOffset, trailerData.byteLength);
+  const offset = view.getBigUint64(8, true);
+  const size = view.getBigUint64(16, true);
+  return { offset, size };
+}

--- a/packages/file-format/src/om_variable.ts
+++ b/packages/file-format/src/om_variable.ts
@@ -3,7 +3,7 @@
 // Supports OmVariableV3_t (scalar) and OmVariableArrayV3_t (array) layouts,
 // plus the legacy OmHeaderV1_t layout.
 
-import { OmDataType, OmCompression, OM_HEADER_V1_SIZE } from "./constants.js";
+import { OmDataType, OmCompression } from "./constants.js";
 
 // Memory layout types (matches C OmMemoryLayout_t)
 const enum MemLayout {
@@ -218,7 +218,7 @@ export class OmVariable {
     // Scalar: name is after base struct + children(16 each) + scalar value
     const baseOff = SIZEOF_V3 + childrenCount * 16;
     const dataType = this.data[V3_OFF_DATA_TYPE] as OmDataType;
-    let scalarSize = 0;
+    let scalarSize: number;
     switch (dataType) {
       case OmDataType.None:
         scalarSize = 0;

--- a/packages/file-format/src/om_variable.ts
+++ b/packages/file-format/src/om_variable.ts
@@ -1,0 +1,311 @@
+// om_variable.ts — OM file variable metadata reader (pure TypeScript)
+//
+// Supports OmVariableV3_t (scalar) and OmVariableArrayV3_t (array) layouts,
+// plus the legacy OmHeaderV1_t layout.
+
+import { OmDataType, OmCompression, OM_HEADER_V1_SIZE } from "./constants.js";
+
+// Memory layout types (matches C OmMemoryLayout_t)
+const enum MemLayout {
+  Legacy = 0,
+  Array = 1,
+  Scalar = 3,
+}
+
+// OmVariableV3_t offsets (8 bytes total):
+//   uint8  data_type        (+0)
+//   uint8  compression_type (+1)
+//   uint16 name_size        (+2)
+//   uint32 children_count   (+4)
+const V3_OFF_DATA_TYPE = 0;
+const V3_OFF_COMPRESSION = 1;
+const V3_OFF_NAME_SIZE = 2;
+const V3_OFF_CHILDREN_COUNT = 4;
+const SIZEOF_V3 = 8;
+
+// OmVariableArrayV3_t offsets (40 bytes total):
+// [V3_OFF_*] same as above for first 8 bytes, then:
+//   uint64 lut_size         (+8)
+//   uint64 lut_offset       (+16)
+//   uint64 dimension_count  (+24)
+//   float  scale_factor     (+32)
+//   float  add_offset       (+36)
+const ARRAY_OFF_LUT_SIZE = 8;
+const ARRAY_OFF_LUT_OFFSET = 16;
+const ARRAY_OFF_DIM_COUNT = 24;
+const ARRAY_OFF_SCALE_FACTOR = 32;
+const ARRAY_OFF_ADD_OFFSET = 36;
+const SIZEOF_ARRAY_V3 = 40;
+
+// Legacy OmHeaderV1_t offsets (40 bytes):
+//   uint8  magic1='O'  (+0)
+//   uint8  magic2='M'  (+1)
+//   uint8  version     (+2)
+//   uint8  compression (+3)   (only for version 2; v1 always PFOR_INT16)
+//   float  scalefactor (+4)
+//   uint32 dim0        (+8)  [but actually uint64]
+//   uint32 dim1        (+16)
+//   uint32 chunk0      (+24)
+//   uint32 chunk1      (+32)
+const LEGACY_OFF_VERSION = 2;
+const LEGACY_OFF_COMPRESSION = 3;
+const LEGACY_OFF_SCALE_FACTOR = 4;
+const LEGACY_OFF_DIM0 = 8;
+const LEGACY_OFF_DIM1 = 16;
+const LEGACY_OFF_CHUNK0 = 24;
+const LEGACY_OFF_CHUNK1 = 32;
+
+function getMemLayout(data: Uint8Array): MemLayout {
+  // Check if legacy (magic bytes 'O','M' + version 1 or 2)
+  if (data[0] === 0x4f && data[1] === 0x4d && (data[2] === 1 || data[2] === 2)) {
+    return MemLayout.Legacy;
+  }
+  // V3: check if array (data_type >= 12 && <= 21)
+  const dataType = data[V3_OFF_DATA_TYPE];
+  if (dataType >= OmDataType.Int8Array && dataType <= OmDataType.DoubleArray) {
+    return MemLayout.Array;
+  }
+  return MemLayout.Scalar;
+}
+
+function readU16LE(data: Uint8Array, off: number): number {
+  return (data[off] | (data[off + 1] << 8)) >>> 0;
+}
+function readU32LE(data: Uint8Array, off: number): number {
+  return (data[off] | (data[off + 1] << 8) | (data[off + 2] << 16) | (data[off + 3] << 24)) >>> 0;
+}
+function readU64LE(data: Uint8Array, off: number): bigint {
+  const lo = readU32LE(data, off);
+  const hi = readU32LE(data, off + 4);
+  return BigInt(lo) | (BigInt(hi) << 32n);
+}
+function readF32LE(data: Uint8Array, off: number): number {
+  const view = new DataView(data.buffer, data.byteOffset + off, 4);
+  return view.getFloat32(0, true);
+}
+
+/**
+ * OmVariable — wraps a raw byte slice representing a variable's metadata.
+ * Implements the same operations as the C om_variable_* functions.
+ */
+export class OmVariable {
+  constructor(public readonly data: Uint8Array) {}
+
+  private get layout(): MemLayout {
+    return getMemLayout(this.data);
+  }
+
+  getDataType(): OmDataType {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) return OmDataType.FloatArray;
+    return this.data[V3_OFF_DATA_TYPE] as OmDataType;
+  }
+
+  getCompression(): OmCompression {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) {
+      if (this.data[LEGACY_OFF_VERSION] === 1) return OmCompression.PforDelta2dInt16;
+      return this.data[LEGACY_OFF_COMPRESSION] as OmCompression;
+    }
+    return this.data[V3_OFF_COMPRESSION] as OmCompression;
+  }
+
+  getScaleFactor(): number {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) return readF32LE(this.data, LEGACY_OFF_SCALE_FACTOR);
+    if (layout === MemLayout.Array) return readF32LE(this.data, ARRAY_OFF_SCALE_FACTOR);
+    return 1;
+  }
+
+  getAddOffset(): number {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) return 0;
+    if (layout === MemLayout.Array) return readF32LE(this.data, ARRAY_OFF_ADD_OFFSET);
+    return 0;
+  }
+
+  getDimensionsCount(): bigint {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) return 2n;
+    if (layout === MemLayout.Array) return readU64LE(this.data, ARRAY_OFF_DIM_COUNT);
+    return 0n;
+  }
+
+  getDimensions(): BigUint64Array {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) {
+      const result = new BigUint64Array(2);
+      result[0] = readU64LE(this.data, LEGACY_OFF_DIM0);
+      result[1] = readU64LE(this.data, LEGACY_OFF_DIM1);
+      return result;
+    }
+    if (layout === MemLayout.Array) {
+      const childrenCount = readU32LE(this.data, V3_OFF_CHILDREN_COUNT);
+      const dimCount = Number(readU64LE(this.data, ARRAY_OFF_DIM_COUNT));
+      const off = SIZEOF_ARRAY_V3 + childrenCount * 16;
+      const result = new BigUint64Array(dimCount);
+      for (let i = 0; i < dimCount; i++) {
+        result[i] = readU64LE(this.data, off + i * 8);
+      }
+      return result;
+    }
+    return new BigUint64Array(0);
+  }
+
+  getChunks(): BigUint64Array {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) {
+      const result = new BigUint64Array(2);
+      result[0] = readU64LE(this.data, LEGACY_OFF_CHUNK0);
+      result[1] = readU64LE(this.data, LEGACY_OFF_CHUNK1);
+      return result;
+    }
+    if (layout === MemLayout.Array) {
+      const childrenCount = readU32LE(this.data, V3_OFF_CHILDREN_COUNT);
+      const dimCount = Number(readU64LE(this.data, ARRAY_OFF_DIM_COUNT));
+      // Chunks come after dimensions array
+      const off = SIZEOF_ARRAY_V3 + childrenCount * 16 + dimCount * 8;
+      const result = new BigUint64Array(dimCount);
+      for (let i = 0; i < dimCount; i++) {
+        result[i] = readU64LE(this.data, off + i * 8);
+      }
+      return result;
+    }
+    return new BigUint64Array(0);
+  }
+
+  getChildrenCount(): number {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) return 0;
+    return readU32LE(this.data, V3_OFF_CHILDREN_COUNT);
+  }
+
+  /** Get offset and size of the i-th child variable. Returns null on error. */
+  getChild(index: number): { offset: bigint; size: bigint } | null {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) return null;
+    const childrenCount = readU32LE(this.data, V3_OFF_CHILDREN_COUNT);
+    if (index < 0 || index >= childrenCount) return null;
+
+    const baseOff = layout === MemLayout.Array ? SIZEOF_ARRAY_V3 : SIZEOF_V3;
+    // sizes array starts right after the base struct
+    const sizesOff = baseOff;
+    // offsets array starts after all sizes
+    const offsetsOff = baseOff + childrenCount * 8;
+
+    const size = readU64LE(this.data, sizesOff + index * 8);
+    const offset = readU64LE(this.data, offsetsOff + index * 8);
+    return { offset, size };
+  }
+
+  getName(): string | null {
+    const layout = this.layout;
+    if (layout === MemLayout.Legacy) return null;
+
+    const nameSize = readU16LE(this.data, V3_OFF_NAME_SIZE);
+    if (nameSize === 0) return null;
+
+    const childrenCount = readU32LE(this.data, V3_OFF_CHILDREN_COUNT);
+
+    if (layout === MemLayout.Array) {
+      const dimCount = Number(readU64LE(this.data, ARRAY_OFF_DIM_COUNT));
+      // Name is after: base struct + children(16 each) + dimensions(8 each) + chunks(8 each)
+      const off = SIZEOF_ARRAY_V3 + childrenCount * 16 + dimCount * 8 + dimCount * 8;
+      const nameBytes = this.data.subarray(off, off + nameSize);
+      return new TextDecoder().decode(nameBytes);
+    }
+
+    // Scalar: name is after base struct + children(16 each) + scalar value
+    const baseOff = SIZEOF_V3 + childrenCount * 16;
+    const dataType = this.data[V3_OFF_DATA_TYPE] as OmDataType;
+    let scalarSize = 0;
+    switch (dataType) {
+      case OmDataType.None:
+        scalarSize = 0;
+        break;
+      case OmDataType.Int8:
+      case OmDataType.Uint8:
+        scalarSize = 1;
+        break;
+      case OmDataType.Int16:
+      case OmDataType.Uint16:
+        scalarSize = 2;
+        break;
+      case OmDataType.Int32:
+      case OmDataType.Uint32:
+      case OmDataType.Float:
+        scalarSize = 4;
+        break;
+      case OmDataType.Int64:
+      case OmDataType.Uint64:
+      case OmDataType.Double:
+        scalarSize = 8;
+        break;
+      case OmDataType.String: {
+        // String: uint64 size + string bytes
+        const strSize = Number(readU64LE(this.data, baseOff));
+        scalarSize = 8 + strSize;
+        break;
+      }
+      default:
+        return null;
+    }
+    const off = baseOff + scalarSize;
+    const nameBytes = this.data.subarray(off, off + nameSize);
+    return new TextDecoder().decode(nameBytes);
+  }
+
+  /** Read a scalar value. Returns the raw bytes and type info, or null. */
+  getScalarBytes(): { bytes: Uint8Array; dataType: OmDataType } | null {
+    const layout = this.layout;
+    if (layout !== MemLayout.Scalar) return null;
+
+    const dataType = this.data[V3_OFF_DATA_TYPE] as OmDataType;
+    const childrenCount = readU32LE(this.data, V3_OFF_CHILDREN_COUNT);
+    const baseOff = SIZEOF_V3 + childrenCount * 16;
+
+    switch (dataType) {
+      case OmDataType.None:
+        return { bytes: new Uint8Array(0), dataType };
+      case OmDataType.Int8:
+      case OmDataType.Uint8:
+        return { bytes: this.data.subarray(baseOff, baseOff + 1), dataType };
+      case OmDataType.Int16:
+      case OmDataType.Uint16:
+        return { bytes: this.data.subarray(baseOff, baseOff + 2), dataType };
+      case OmDataType.Int32:
+      case OmDataType.Uint32:
+      case OmDataType.Float:
+        return { bytes: this.data.subarray(baseOff, baseOff + 4), dataType };
+      case OmDataType.Int64:
+      case OmDataType.Uint64:
+      case OmDataType.Double:
+        return { bytes: this.data.subarray(baseOff, baseOff + 8), dataType };
+      case OmDataType.String: {
+        const strSize = Number(readU64LE(this.data, baseOff));
+        return { bytes: this.data.subarray(baseOff + 8, baseOff + 8 + strSize), dataType };
+      }
+      default:
+        return null;
+    }
+  }
+
+  /** Get LUT metadata (only valid for Array layout). */
+  getLutInfo(): { lutSize: bigint; lutOffset: bigint } | null {
+    if (this.layout !== MemLayout.Array) return null;
+    return {
+      lutSize: readU64LE(this.data, ARRAY_OFF_LUT_SIZE),
+      lutOffset: readU64LE(this.data, ARRAY_OFF_LUT_OFFSET),
+    };
+  }
+
+  isLegacy(): boolean {
+    return this.layout === MemLayout.Legacy;
+  }
+  isArray(): boolean {
+    return this.layout === MemLayout.Array;
+  }
+  isScalar(): boolean {
+    return this.layout === MemLayout.Scalar;
+  }
+}

--- a/packages/file-format/src/turbopfor.ts
+++ b/packages/file-format/src/turbopfor.ts
@@ -165,41 +165,67 @@ function bitunpackHoriz64(
 // For vertical format, plane j (0-indexed) is stored at src[offset + j*16 .. j*16+15].
 // Bit j of value i is at: src[offset + j*16 + (i>>>3)], bit position (i&7).
 
-function bitunpackVert16(
-  src: Uint8Array,
-  offset: number,
-  b: number,
-  dst: Uint16Array,
-  dstOff: number,
-  count: number
-): void {
-  for (let i = 0; i < count; i++) dst[dstOff + i] = 0;
-  for (let bit = 0; bit < b; bit++) {
-    const planeStart = offset + bit * 16;
-    for (let i = 0; i < count; i++) {
-      if (src[planeStart + (i >>> 3)] & (1 << (i & 7))) {
-        dst[dstOff + i] |= 1 << bit;
+// Decode 128 values at b bits each using the 128v SIMD horizontal-per-lane format.
+// Data is stored in 8 interleaved uint16 "lanes" (one per SIMD lane):
+//   output[p*8 + lane] comes from uint16 at byte (wordIdx*16 + lane*2),
+//   where wordIdx = floor((p*b) / 16), at bit (p*b) % 16 within that uint16.
+// Total bytes consumed: b * 16 = PAD8(128 * b).
+function bitunpack128v16(src: Uint8Array, offset: number, b: number, dst: Uint16Array, dstOff: number): void {
+  if (b === 0) {
+    for (let k = 0; k < 128; k++) dst[dstOff + k] = 0;
+    return;
+  }
+  const mask = b < 16 ? (1 << b) - 1 : 0xffff;
+  for (let lane = 0; lane < 8; lane++) {
+    const laneBase = offset + lane * 2;
+    let bitPos = 0;
+    for (let p = 0; p < 16; p++) {
+      const wordIdx = (bitPos >>> 4); // floor(bitPos / 16)
+      const bitInWord = bitPos & 15;
+      const byteOff = laneBase + wordIdx * 16;
+      const word0 = src[byteOff] | (src[byteOff + 1] << 8);
+      let val: number;
+      if (bitInWord + b <= 16) {
+        val = (word0 >>> bitInWord) & mask;
+      } else {
+        const word1 = src[byteOff + 16] | (src[byteOff + 17] << 8);
+        val = ((word0 >>> bitInWord) | (word1 << (16 - bitInWord))) & mask;
       }
+      dst[dstOff + p * 8 + lane] = val;
+      bitPos += b;
     }
   }
 }
 
-function bitunpackVert32(
-  src: Uint8Array,
-  offset: number,
-  b: number,
-  dst: Uint32Array,
-  dstOff: number,
-  count: number
-): void {
-  for (let i = 0; i < count; i++) dst[dstOff + i] = 0;
-  for (let bit = 0; bit < b; bit++) {
-    const planeStart = offset + bit * 16;
-    const bitMask = bit < 31 ? 1 << bit : 0x80000000; // handle bit 31 separately
-    for (let i = 0; i < count; i++) {
-      if (src[planeStart + (i >>> 3)] & (1 << (i & 7))) {
-        dst[dstOff + i] = (dst[dstOff + i] | bitMask) >>> 0;
+// Decode 128 values at b bits each using the 128v SIMD horizontal-per-lane format for 32-bit.
+// 4 uint32 lanes, 32 values per lane.
+// output[p*4 + lane] comes from uint32 at byte (wordIdx*16 + lane*4),
+// where wordIdx = floor((p*b) / 32), at bit (p*b) % 32.
+function bitunpack128v32(src: Uint8Array, offset: number, b: number, dst: Uint32Array, dstOff: number): void {
+  if (b === 0) {
+    for (let k = 0; k < 128; k++) dst[dstOff + k] = 0;
+    return;
+  }
+  const mask = b < 32 ? (1 << b) - 1 : -1; // -1 = 0xFFFFFFFF
+  for (let lane = 0; lane < 4; lane++) {
+    const laneBase = offset + lane * 4;
+    let bitPos = 0;
+    for (let p = 0; p < 32; p++) {
+      const wordIdx = (bitPos / 32) | 0;
+      const bitInWord = bitPos % 32;
+      const byteOff = laneBase + wordIdx * 16;
+      const word0 = (src[byteOff] | (src[byteOff + 1] << 8) | (src[byteOff + 2] << 16) | (src[byteOff + 3] << 24)) >>> 0;
+      let val: number;
+      if (bitInWord === 0) {
+        val = (word0 & mask) >>> 0;
+      } else if (bitInWord + b <= 32) {
+        val = (word0 >>> bitInWord) & mask;
+      } else {
+        const word1 = (src[byteOff + 16] | (src[byteOff + 17] << 8) | (src[byteOff + 18] << 16) | (src[byteOff + 19] << 24)) >>> 0;
+        val = ((word0 >>> bitInWord) | ((word1 << (32 - bitInWord)) >>> 0)) & mask;
       }
+      dst[dstOff + p * 4 + lane] = val >>> 0;
+      bitPos += b;
     }
   }
 }
@@ -316,13 +342,12 @@ function decodeBlock128v16(
           byte &= byte - 1;
         }
       }
-      // Horizontal unpack exceptions at bx bits
-      const exBytes = bitunpackHoriz16(src, ip, nEx, bx, _ex16, 0);
-      ip += exBytes;
+        // Scalar horizontal unpack exceptions at bx bits
+      ip += bitunpackHoriz16(src, ip, nEx, bx, _ex16, 0);
     }
 
-    // Vertical bitpack main values
-    bitunpackVert16(src, ip, mainBits, _tmp16, 0, CSIZE);
+    // 128v SIMD format for main values
+    bitunpack128v16(src, ip, mainBits, _tmp16, 0);
     ip += mainBits * 16;
 
     // Merge exceptions
@@ -364,8 +389,9 @@ function decodeBlock128v16(
     const bx = src[ip++]; // number of exceptions
 
     // Horizontal unpack CSIZE values at mainBits bits
-    const mainBytes = bitunpackHoriz16(src, ip, CSIZE, mainBits, _tmp16, 0);
-    ip += mainBytes;
+    // 128v SIMD format for main values in VB exception mode
+    bitunpack128v16(src, ip, mainBits, _tmp16, 0);
+    ip += mainBits * 16;
 
     // Decode bx exception values using vb encoding
     const exDst = _ex16 as unknown as Uint32Array; // reuse buffer
@@ -580,11 +606,11 @@ function decodeBlock128v32(
           byte &= byte - 1;
         }
       }
-      const exBytes = bitunpackHoriz32(src, ip, nEx, bx, _ex32, 0);
-      ip += exBytes;
+      ip += bitunpackHoriz32(src, ip, nEx, bx, _ex32, 0);
     }
 
-    bitunpackVert32(src, ip, mainBits, _tmp32, 0, CSIZE);
+    // 128v SIMD format for main values
+    bitunpack128v32(src, ip, mainBits, _tmp32, 0);
     ip += mainBits * 16;
 
     if (hasExceptions) {
@@ -619,8 +645,9 @@ function decodeBlock128v32(
   {
     const mainBits = b & 0x3f;
     const bx = src[ip++];
-    const mainBytes = bitunpackHoriz32(src, ip, CSIZE, mainBits, _tmp32, 0);
-    ip += mainBytes;
+    // 128v SIMD format for main values in VB exception mode
+    bitunpack128v32(src, ip, mainBits, _tmp32, 0);
+    ip += mainBits * 16;
     ip = vbdec32(src, ip, bx, _ex32, 0);
     for (let j = 0; j < bx; j++) {
       const pos = src[ip + j];
@@ -1300,10 +1327,9 @@ export function p4dec128v32_block(src: Uint8Array, ip: number, n: number, dst: U
           by &= by - 1;
         }
       }
-      const exBytes = bitunpackHoriz32(src, ip, nEx, bx, _ex32, 0);
-      ip += exBytes;
+      ip += bitunpackHoriz32(src, ip, nEx, bx, _ex32, 0);
       if (n === CSIZE) {
-        bitunpackVert32(src, ip, mainBits, _tmp32, 0, n);
+        bitunpack128v32(src, ip, mainBits, _tmp32, 0);
         ip += mainBits * 16;
       } else {
         ip += bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
@@ -1321,7 +1347,7 @@ export function p4dec128v32_block(src: Uint8Array, ip: number, n: number, dst: U
       }
     } else {
       if (n === CSIZE) {
-        bitunpackVert32(src, ip, mainBits, _tmp32, 0, n);
+        bitunpack128v32(src, ip, mainBits, _tmp32, 0);
         ip += mainBits * 16;
       } else {
         ip += bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
@@ -1334,7 +1360,12 @@ export function p4dec128v32_block(src: Uint8Array, ip: number, n: number, dst: U
   {
     const mainBits = b & 0x3f;
     const bxCount = src[ip++];
-    ip += bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
+    if (n === CSIZE) {
+      bitunpack128v32(src, ip, mainBits, _tmp32, 0);
+      ip += mainBits * 16;
+    } else {
+      ip += bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
+    }
     ip = vbdec32(src, ip, bxCount, _ex32, 0);
     for (let j = 0; j < bxCount; j++) {
       const pos = src[ip + j];

--- a/packages/file-format/src/turbopfor.ts
+++ b/packages/file-format/src/turbopfor.ts
@@ -899,8 +899,8 @@ function _traceBlock16(src: Uint8Array, ip: number, n: number): { type: string; 
 
   if (!(b & 0x40)) {
     const mainBits = b & 0x3f;
-    let exBytes = 0;
-    let bitmapBytes = 0;
+    let exBytes: number;
+    let bitmapBytes: number;
     if (b & 0x80) {
       const bx = src[ip++];
       if (n === CSIZE) {
@@ -915,7 +915,6 @@ function _traceBlock16(src: Uint8Array, ip: number, n: number): { type: string; 
           }
         }
         exBytes = Math.ceil((nEx * bx) / 8);
-        ip += 16 + exBytes;
       } else {
         // Partial block: ceil(n/8) byte bitmap
         const p4dn = (n + 7) >> 3;
@@ -930,7 +929,6 @@ function _traceBlock16(src: Uint8Array, ip: number, n: number): { type: string; 
           }
         }
         exBytes = Math.ceil((nEx * bx) / 8);
-        ip += p4dn + exBytes;
       }
       const mainBytes = n === CSIZE ? mainBits * 16 : Math.ceil((n * mainBits) / 8);
       return {

--- a/packages/file-format/src/turbopfor.ts
+++ b/packages/file-format/src/turbopfor.ts
@@ -1,0 +1,1374 @@
+// turbopfor.ts — TurboPFor integer compression decoder (pure TypeScript)
+//
+// Supports:
+//   p4nzdec128v16 — zigzag PFor, 128v vertical, 16-bit (used for PforDelta2dInt16)
+//   p4nddec128v16 — delta PFor, 128v vertical, 16-bit
+//   p4nzdec128v32 — zigzag PFor, 128v vertical, 32-bit
+//   p4nddec128v32 — delta PFor, 128v vertical, 32-bit
+//   p4nzdec8      — zigzag PFor, scalar horizontal, 8-bit
+//   p4nddec8      — delta PFor, scalar horizontal, 8-bit
+//   p4nzdec64     — zigzag PFor, scalar horizontal, 64-bit (BigInt)
+//   p4nddec64     — delta PFor, scalar horizontal, 64-bit (BigInt)
+//
+// All functions return the number of compressed bytes consumed.
+
+import { vbxget16, vbxget32, vbxget64 } from "./vbx.js";
+
+const CSIZE = 128; // Block size
+
+// ─── Zigzag decode ─────────────────────────────────────────────────────────
+
+function zigzagdec16(x: number): number {
+  // Treat x as unsigned 16-bit, output signed result as JS number
+  return (x >>> 1) ^ -(x & 1);
+}
+
+function zigzagdec32(x: number): number {
+  // Treat x as unsigned 32-bit
+  return ((x >>> 1) ^ -(x & 1)) | 0; // keep as signed int32
+}
+
+function zigzagdec64(x: bigint): bigint {
+  return (x >> 1n) ^ -(x & 1n);
+}
+
+// ─── Horizontal bit unpack ─────────────────────────────────────────────────
+// Decodes `n` values at `b` bits each from src[offset..] using LSB-first horizontal packing.
+// Fills dst[dstOff..dstOff+n-1] with unsigned values.
+// Returns number of bytes consumed.
+
+function bitunpackHoriz16(
+  src: Uint8Array,
+  offset: number,
+  n: number,
+  b: number,
+  dst: Uint16Array | Int16Array,
+  dstOff: number
+): number {
+  if (b === 0) {
+    for (let i = 0; i < n; i++) dst[dstOff + i] = 0;
+    return 0;
+  }
+  const mask = b < 16 ? (1 << b) - 1 : 0xffff;
+  let bitPos = 0;
+  for (let i = 0; i < n; i++) {
+    const bytePos = bitPos >>> 3;
+    const bitInByte = bitPos & 7;
+    // Read 32 bits to handle up to 16-bit values at any bit alignment
+    const w =
+      (src[offset + bytePos] |
+        (src[offset + bytePos + 1] << 8) |
+        (src[offset + bytePos + 2] << 16) |
+        (src[offset + bytePos + 3] << 24)) >>>
+      0;
+    dst[dstOff + i] = (w >>> bitInByte) & mask;
+    bitPos += b;
+  }
+  return (bitPos + 7) >>> 3;
+}
+
+function bitunpackHoriz32(
+  src: Uint8Array,
+  offset: number,
+  n: number,
+  b: number,
+  dst: Uint32Array | Int32Array,
+  dstOff: number
+): number {
+  if (b === 0) {
+    for (let i = 0; i < n; i++) dst[dstOff + i] = 0;
+    return 0;
+  }
+  const mask = b < 32 ? (1 << b) - 1 : -1; // -1 = 0xFFFFFFFF as int32
+  let bitPos = 0;
+  for (let i = 0; i < n; i++) {
+    const bytePos = bitPos >>> 3;
+    const bitInByte = bitPos & 7;
+    // Read 64 bits via two 32-bit reads to handle 32-bit values at any alignment
+    const lo =
+      (src[offset + bytePos] |
+        (src[offset + bytePos + 1] << 8) |
+        (src[offset + bytePos + 2] << 16) |
+        (src[offset + bytePos + 3] << 24)) >>>
+      0;
+    if (bitInByte === 0) {
+      dst[dstOff + i] = lo & mask;
+    } else {
+      const hi =
+        (src[offset + bytePos + 4] |
+          (src[offset + bytePos + 5] << 8) |
+          (src[offset + bytePos + 6] << 16) |
+          (src[offset + bytePos + 7] << 24)) >>>
+        0;
+      dst[dstOff + i] = ((lo >>> bitInByte) | (hi << (32 - bitInByte))) & mask;
+    }
+    bitPos += b;
+  }
+  return (bitPos + 7) >>> 3;
+}
+
+function bitunpackHoriz8(
+  src: Uint8Array,
+  offset: number,
+  n: number,
+  b: number,
+  dst: Uint8Array | Int8Array,
+  dstOff: number
+): number {
+  if (b === 0) {
+    for (let i = 0; i < n; i++) dst[dstOff + i] = 0;
+    return 0;
+  }
+  const mask = (1 << b) - 1;
+  let bitPos = 0;
+  for (let i = 0; i < n; i++) {
+    const bytePos = bitPos >>> 3;
+    const bitInByte = bitPos & 7;
+    const w = (src[offset + bytePos] | (src[offset + bytePos + 1] << 8)) >>> 0;
+    dst[dstOff + i] = (w >>> bitInByte) & mask;
+    bitPos += b;
+  }
+  return (bitPos + 7) >>> 3;
+}
+
+function bitunpackHoriz64(
+  src: Uint8Array,
+  offset: number,
+  n: number,
+  b: number,
+  dst: BigUint64Array | BigInt64Array,
+  dstOff: number
+): number {
+  if (b === 0) {
+    for (let i = 0; i < n; i++) dst[dstOff + i] = 0n;
+    return 0;
+  }
+  const bBig = BigInt(b);
+  const mask = b < 64 ? (1n << bBig) - 1n : 0xffffffffffffffffn;
+  let bitPos = 0;
+  for (let i = 0; i < n; i++) {
+    const bytePos = bitPos >>> 3;
+    const bitInByte = bitPos & 7;
+    // Read 9 bytes (72 bits) to cover a 64-bit value at any bit alignment
+    let w = 0n;
+    for (let j = 0; j < 9; j++) {
+      w |= BigInt(src[offset + bytePos + j] ?? 0) << BigInt(j * 8);
+    }
+    dst[dstOff + i] = (w >> BigInt(bitInByte)) & mask;
+    bitPos += b;
+  }
+  return (bitPos + 7) >>> 3;
+}
+
+// ─── Vertical 128v bit unpack ──────────────────────────────────────────────
+// Decodes `count` values (1..128) at `b` bits per value from vertical bit planes.
+// For vertical format, plane j (0-indexed) is stored at src[offset + j*16 .. j*16+15].
+// Bit j of value i is at: src[offset + j*16 + (i>>>3)], bit position (i&7).
+
+function bitunpackVert16(
+  src: Uint8Array,
+  offset: number,
+  b: number,
+  dst: Uint16Array,
+  dstOff: number,
+  count: number
+): void {
+  for (let i = 0; i < count; i++) dst[dstOff + i] = 0;
+  for (let bit = 0; bit < b; bit++) {
+    const planeStart = offset + bit * 16;
+    for (let i = 0; i < count; i++) {
+      if (src[planeStart + (i >>> 3)] & (1 << (i & 7))) {
+        dst[dstOff + i] |= 1 << bit;
+      }
+    }
+  }
+}
+
+function bitunpackVert32(
+  src: Uint8Array,
+  offset: number,
+  b: number,
+  dst: Uint32Array,
+  dstOff: number,
+  count: number
+): void {
+  for (let i = 0; i < count; i++) dst[dstOff + i] = 0;
+  for (let bit = 0; bit < b; bit++) {
+    const planeStart = offset + bit * 16;
+    const bitMask = bit < 31 ? 1 << bit : 0x80000000; // handle bit 31 separately
+    for (let i = 0; i < count; i++) {
+      if (src[planeStart + (i >>> 3)] & (1 << (i & 7))) {
+        dst[dstOff + i] = (dst[dstOff + i] | bitMask) >>> 0;
+      }
+    }
+  }
+}
+
+// ─── Variable-byte (vb) decode for exceptions in 0x40 mode ────────────────
+// Different from vbx! Uses a different byte layout with VB_OFS1=177, etc.
+
+const VB_OFS1 = 177;
+const VB_BA2 = 241;
+const VB_BA3 = 249;
+const VB_OFS2 = 16561;
+
+function vbget32_single(src: Uint8Array, offset: number): [number, number] {
+  let x = src[offset++];
+  if (x < VB_OFS1) return [x, offset];
+  if (x < VB_BA2) {
+    const next = src[offset++];
+    return [(x << 8) + next + (VB_OFS1 - (VB_OFS1 << 8)), offset];
+  }
+  if (x < VB_BA3) {
+    const lo16 = src[offset] | (src[offset + 1] << 8);
+    offset += 2;
+    return [lo16 + ((x - VB_BA2) << 16) + VB_OFS2, offset];
+  }
+  // Larger: b = x - VB_BA3 extra bytes
+  const bExtra = x - VB_BA3;
+  let val = 0;
+  for (let i = 0; i < 3 + bExtra && i < 4; i++) {
+    val |= src[offset + i] << (i * 8);
+  }
+  val = val >>> 0;
+  offset += 3 + bExtra;
+  return [val, offset];
+}
+
+// Decode n variable-byte encoded values
+function vbdec32(src: Uint8Array, offset: number, n: number, dst: Uint32Array, dstOff: number): number {
+  for (let i = 0; i < n; i++) {
+    const [v, newOff] = vbget32_single(src, offset);
+    dst[dstOff + i] = v;
+    offset = newOff;
+  }
+  return offset;
+}
+
+// ─── Block decoder helpers ─────────────────────────────────────────────────
+
+// Shared temp buffers (reused across calls to avoid GC pressure)
+// Extra CSIZE room for exceptions stored after main values
+const _tmp16 = new Uint16Array(CSIZE * 2 + 8);
+const _tmp32 = new Uint32Array(CSIZE * 2 + 8);
+const _ex16 = new Uint16Array(CSIZE * 2 + 8);
+const _ex32 = new Uint32Array(CSIZE * 2 + 8);
+const _bitmapBuf = new Uint8Array(16);
+
+// Decode one full block (CSIZE=128) for 16-bit, using 128v vertical format.
+// Returns bytes consumed.
+// `start` (by reference via array) is updated to last accumulated value.
+function decodeBlock128v16(
+  src: Uint8Array,
+  ip: number,
+  dst: Uint16Array,
+  dstOff: number,
+  startArr: Int32Array, // [0] = start (int32 to handle signed delta)
+  isZigzag: boolean
+): number {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+    const mainBits = b & 0x3f;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    let v = 0;
+    for (let j = 0; j < bytesNeeded; j++) v |= src[ip + j] << (j * 8);
+    if (mainBits < 16) v &= (1 << mainBits) - 1;
+    v &= 0xffff;
+    ip += bytesNeeded;
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + zigzagdec16(v)) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + v) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  if (!(b & 0x40)) {
+    // Pure vertical bitpack (b & 0x80 == 0) or bitmap exceptions (b & 0x80 != 0)
+    let mainBits = b & 0x3f;
+    let bx = 0;
+    let hasExceptions = false;
+
+    if (b & 0x80) {
+      // Bitmap exceptions
+      bx = src[ip++];
+      hasExceptions = true;
+      // Copy 16-byte bitmap
+      for (let j = 0; j < 16; j++) _bitmapBuf[j] = src[ip + j];
+      ip += 16;
+      // Count exceptions via popcount
+      let nEx = 0;
+      for (let j = 0; j < 16; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          nEx++;
+          byte &= byte - 1;
+        }
+      }
+      // Horizontal unpack exceptions at bx bits
+      const exBytes = bitunpackHoriz16(src, ip, nEx, bx, _ex16, 0);
+      ip += exBytes;
+    }
+
+    // Vertical bitpack main values
+    bitunpackVert16(src, ip, mainBits, _tmp16, 0, CSIZE);
+    ip += mainBits * 16;
+
+    // Merge exceptions
+    if (hasExceptions) {
+      let k = 0;
+      for (let j = 0; j < 16; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          const bitPos = Math.clz32(byte ^ (byte - 1)) ^ 31; // ctz: index of lowest set bit
+          // Actually: ctz = number of trailing zeros
+          const ctz = 31 - Math.clz32(byte & -byte);
+          const pos = j * 8 + ctz;
+          _tmp16[pos] = (_tmp16[pos] + (_ex16[k++] << mainBits)) & 0xffff;
+          byte &= byte - 1;
+        }
+      }
+    }
+
+    // Apply delta/zigzag transform
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + zigzagdec16(_tmp16[i])) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + _tmp16[i]) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  // Variable-byte exception mode (b & 0x40 set, b & 0x80 not set)
+  {
+    const mainBits = b & 0x3f;
+    const bx = src[ip++]; // number of exceptions
+
+    // Horizontal unpack CSIZE values at mainBits bits
+    const mainBytes = bitunpackHoriz16(src, ip, CSIZE, mainBits, _tmp16, 0);
+    ip += mainBytes;
+
+    // Decode bx exception values using vb encoding
+    const exDst = _ex16 as unknown as Uint32Array; // reuse buffer
+    ip = vbdec32(src, ip, bx, exDst, 0);
+
+    // Read bx position indices (byte values)
+    for (let j = 0; j < bx; j++) {
+      const pos = src[ip + j];
+      _tmp16[pos] = (_tmp16[pos] | (exDst[j] << mainBits)) & 0xffff;
+    }
+    ip += bx;
+
+    // Apply delta/zigzag
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + zigzagdec16(_tmp16[i])) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + _tmp16[i]) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+}
+
+// Decode partial block (n < CSIZE) for 16-bit using HORIZONTAL scalar format.
+function decodePartialBlock16(
+  src: Uint8Array,
+  ip: number,
+  n: number,
+  dst: Uint16Array,
+  dstOff: number,
+  startArr: Int32Array,
+  isZigzag: boolean
+): number {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+    const mainBits = b & 0x3f;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    let v = 0;
+    for (let j = 0; j < bytesNeeded; j++) v |= src[ip + j] << (j * 8);
+    if (mainBits < 16) v &= (1 << mainBits) - 1;
+    v &= 0xffff;
+    ip += bytesNeeded;
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < n; i++) {
+        s = (s + zigzagdec16(v)) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        s = (s + v) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  if (!(b & 0x40)) {
+    const mainBits = b & 0x3f;
+    let bx = 0;
+    let hasExceptions = false;
+
+    if (b & 0x80) {
+      bx = src[ip++];
+      hasExceptions = true;
+      // Scalar partial-block format: ceil(n/8) bytes for position bitmap (1 bit per element)
+      const p4dn = (n + 7) >> 3;
+      let nEx = 0;
+      for (let j = 0; j < p4dn; j++) {
+        let byte = src[ip + j];
+        if (j === p4dn - 1 && (n & 7) !== 0) byte &= (1 << (n & 7)) - 1;
+        _bitmapBuf[j] = byte;
+        while (byte) {
+          nEx++;
+          byte &= byte - 1;
+        }
+      }
+      ip += p4dn;
+      const exBytes = bitunpackHoriz16(src, ip, nEx, bx, _ex16, 0);
+      ip += exBytes;
+    }
+
+    // Horizontal scalar unpack for partial blocks
+    const mainBytes = bitunpackHoriz16(src, ip, n, mainBits, _tmp16, 0);
+    ip += mainBytes;
+
+    if (hasExceptions) {
+      const p4dn = (n + 7) >> 3;
+      let k = 0;
+      for (let j = 0; j < p4dn; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          const ctz = 31 - Math.clz32(byte & -byte);
+          const pos = j * 8 + ctz;
+          if (pos < n) {
+            _tmp16[pos] = (_tmp16[pos] + (_ex16[k] << mainBits)) & 0xffff;
+          }
+          k++;
+          byte &= byte - 1;
+        }
+      }
+    }
+
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < n; i++) {
+        s = (s + zigzagdec16(_tmp16[i])) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        s = (s + _tmp16[i]) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  {
+    const mainBits = b & 0x3f;
+    const bx = src[ip++];
+    const mainBytes = bitunpackHoriz16(src, ip, n, mainBits, _tmp16, 0);
+    ip += mainBytes;
+    const exDst = _ex16 as unknown as Uint32Array;
+    ip = vbdec32(src, ip, bx, exDst, 0);
+    for (let j = 0; j < bx; j++) {
+      const pos = src[ip + j];
+      if (pos < n) _tmp16[pos] = (_tmp16[pos] | (exDst[j] << mainBits)) & 0xffff;
+    }
+    ip += bx;
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < n; i++) {
+        s = (s + zigzagdec16(_tmp16[i])) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        s = (s + _tmp16[i]) & 0xffff;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+}
+
+// Decode one full block (CSIZE=128) for 32-bit, using 128v vertical format.
+function decodeBlock128v32(
+  src: Uint8Array,
+  ip: number,
+  dst: Uint32Array,
+  dstOff: number,
+  startArr: Float64Array, // [0] = start as unsigned 32-bit number
+  isZigzag: boolean
+): number {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+    const mainBits = b & 0x3f;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    let v = 0;
+    for (let j = 0; j < bytesNeeded; j++) v |= src[ip + j] << (j * 8);
+    if (mainBits < 32) v &= (1 << mainBits) - 1;
+    v >>>= 0;
+    ip += bytesNeeded;
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + zigzagdec32(v)) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + v) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  if (!(b & 0x40)) {
+    const mainBits = b & 0x3f;
+    let bx = 0;
+    let hasExceptions = false;
+
+    if (b & 0x80) {
+      bx = src[ip++];
+      hasExceptions = true;
+      for (let j = 0; j < 16; j++) _bitmapBuf[j] = src[ip + j];
+      ip += 16;
+      let nEx = 0;
+      for (let j = 0; j < 16; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          nEx++;
+          byte &= byte - 1;
+        }
+      }
+      const exBytes = bitunpackHoriz32(src, ip, nEx, bx, _ex32, 0);
+      ip += exBytes;
+    }
+
+    bitunpackVert32(src, ip, mainBits, _tmp32, 0, CSIZE);
+    ip += mainBits * 16;
+
+    if (hasExceptions) {
+      let k = 0;
+      for (let j = 0; j < 16; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          const ctz = 31 - Math.clz32(byte & -byte);
+          const pos = j * 8 + ctz;
+          _tmp32[pos] = (_tmp32[pos] + (_ex32[k++] << mainBits)) >>> 0;
+          byte &= byte - 1;
+        }
+      }
+    }
+
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + zigzagdec32(_tmp32[i])) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + _tmp32[i]) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  {
+    const mainBits = b & 0x3f;
+    const bx = src[ip++];
+    const mainBytes = bitunpackHoriz32(src, ip, CSIZE, mainBits, _tmp32, 0);
+    ip += mainBytes;
+    ip = vbdec32(src, ip, bx, _ex32, 0);
+    for (let j = 0; j < bx; j++) {
+      const pos = src[ip + j];
+      _tmp32[pos] = (_tmp32[pos] | (_ex32[j] << mainBits)) >>> 0;
+    }
+    ip += bx;
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + zigzagdec32(_tmp32[i])) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < CSIZE; i++) {
+        s = (s + _tmp32[i]) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+}
+
+// Decode partial block (n < CSIZE) for 32-bit using HORIZONTAL scalar format.
+function decodePartialBlock32(
+  src: Uint8Array,
+  ip: number,
+  n: number,
+  dst: Uint32Array,
+  dstOff: number,
+  startArr: Float64Array,
+  isZigzag: boolean
+): number {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+    const mainBits = b & 0x3f;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    let v = 0;
+    for (let j = 0; j < bytesNeeded; j++) v |= src[ip + j] << (j * 8);
+    if (mainBits < 32) v &= (1 << mainBits) - 1;
+    v >>>= 0;
+    ip += bytesNeeded;
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < n; i++) {
+        s = (s + zigzagdec32(v)) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        s = (s + v) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  if (!(b & 0x40)) {
+    const mainBits = b & 0x3f;
+    let bx = 0;
+    let hasExceptions = false;
+
+    if (b & 0x80) {
+      bx = src[ip++];
+      hasExceptions = true;
+      // Scalar partial-block format: ceil(n/8) bytes for position bitmap (1 bit per element)
+      const p4dn = (n + 7) >> 3;
+      let nEx = 0;
+      for (let j = 0; j < p4dn; j++) {
+        let byte = src[ip + j];
+        // mask the last byte to ignore bits beyond n
+        if (j === p4dn - 1 && (n & 7) !== 0) byte &= (1 << (n & 7)) - 1;
+        _bitmapBuf[j] = byte;
+        while (byte) {
+          nEx++;
+          byte &= byte - 1;
+        }
+      }
+      ip += p4dn;
+      const exBytes = bitunpackHoriz32(src, ip, nEx, bx, _ex32, 0);
+      ip += exBytes;
+    }
+
+    const mainBytes = bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
+    ip += mainBytes;
+
+    if (hasExceptions) {
+      const p4dn = (n + 7) >> 3;
+      let k = 0;
+      for (let j = 0; j < p4dn; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          const ctz = 31 - Math.clz32(byte & -byte);
+          const pos = j * 8 + ctz;
+          if (pos < n) {
+            _tmp32[pos] = (_tmp32[pos] + (_ex32[k] << mainBits)) >>> 0;
+          }
+          k++;
+          byte &= byte - 1;
+        }
+      }
+    }
+
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < n; i++) {
+        s = (s + zigzagdec32(_tmp32[i])) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        s = (s + _tmp32[i]) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+
+  {
+    const mainBits = b & 0x3f;
+    const bx = src[ip++];
+    const mainBytes = bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
+    ip += mainBytes;
+    ip = vbdec32(src, ip, bx, _ex32, 0);
+    for (let j = 0; j < bx; j++) {
+      const pos = src[ip + j];
+      if (pos < n) _tmp32[pos] = (_tmp32[pos] | (_ex32[j] << mainBits)) >>> 0;
+    }
+    ip += bx;
+    let s = startArr[0];
+    if (isZigzag) {
+      for (let i = 0; i < n; i++) {
+        s = (s + zigzagdec32(_tmp32[i])) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        s = (s + _tmp32[i]) >>> 0;
+        dst[dstOff + i] = s;
+      }
+    }
+    startArr[0] = s;
+    return ip - ipStart;
+  }
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+const _startArr16 = new Int32Array(1);
+const _startArr32 = new Float64Array(1);
+
+/**
+ * Zigzag-delta PFor decode, 128v vertical format, 16-bit.
+ * Used for COMPRESSION_PFOR_DELTA2D_INT16.
+ * Returns bytes consumed.
+ */
+export function p4nzdec128v16(src: Uint8Array, srcOff: number, n: number, dst: Uint16Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+
+  // Read first value (vbx-encoded)
+  const [startVal, newIp] = vbxget16(src, ip);
+  ip = newIp;
+  dst[dstOff] = startVal & 0xffff;
+  _startArr16[0] = startVal & 0xffff;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  // Full blocks of CSIZE=128
+  while (remaining >= CSIZE) {
+    ip += decodeBlock128v16(src, ip, dst, op, _startArr16, true);
+    op += CSIZE;
+    remaining -= CSIZE;
+  }
+
+  // Partial final block
+  if (remaining > 0) {
+    ip += decodePartialBlock16(src, ip, remaining, dst, op, _startArr16, true);
+  }
+
+  return ip - srcOff;
+}
+
+/**
+ * Delta PFor decode, 128v vertical format, 16-bit.
+ * Returns bytes consumed.
+ */
+export function p4nddec128v16(src: Uint8Array, srcOff: number, n: number, dst: Uint16Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+
+  const [startVal, newIp] = vbxget16(src, ip);
+  ip = newIp;
+  dst[dstOff] = startVal & 0xffff;
+  _startArr16[0] = startVal & 0xffff;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  while (remaining >= CSIZE) {
+    ip += decodeBlock128v16(src, ip, dst, op, _startArr16, false);
+    op += CSIZE;
+    remaining -= CSIZE;
+  }
+
+  if (remaining > 0) {
+    ip += decodePartialBlock16(src, ip, remaining, dst, op, _startArr16, false);
+  }
+
+  return ip - srcOff;
+}
+
+/**
+ * Zigzag-delta PFor decode, 128v vertical format, 32-bit.
+ * Returns bytes consumed.
+ */
+export function p4nzdec128v32(src: Uint8Array, srcOff: number, n: number, dst: Uint32Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+
+  const [startVal, newIp] = vbxget32(src, ip);
+  ip = newIp;
+  dst[dstOff] = startVal >>> 0;
+  _startArr32[0] = startVal >>> 0;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  while (remaining >= CSIZE) {
+    ip += decodeBlock128v32(src, ip, dst, op, _startArr32, true);
+    op += CSIZE;
+    remaining -= CSIZE;
+  }
+
+  if (remaining > 0) {
+    ip += decodePartialBlock32(src, ip, remaining, dst, op, _startArr32, true);
+  }
+
+  return ip - srcOff;
+}
+
+/**
+ * Delta PFor decode, 128v vertical format, 32-bit.
+ * Returns bytes consumed.
+ */
+export function p4nddec128v32(src: Uint8Array, srcOff: number, n: number, dst: Uint32Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+
+  const [startVal, newIp] = vbxget32(src, ip);
+  ip = newIp;
+  dst[dstOff] = startVal >>> 0;
+  _startArr32[0] = startVal >>> 0;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  while (remaining >= CSIZE) {
+    ip += decodeBlock128v32(src, ip, dst, op, _startArr32, false);
+    op += CSIZE;
+    remaining -= CSIZE;
+  }
+
+  if (remaining > 0) {
+    ip += decodePartialBlock32(src, ip, remaining, dst, op, _startArr32, false);
+  }
+
+  return ip - srcOff;
+}
+
+// ─── 8-bit scalar horizontal block decoder ────────────────────────────────
+
+const _tmp8 = new Uint8Array(CSIZE * 2 + 8);
+const _ex8 = new Uint32Array(CSIZE + 8);
+
+function decodeBlockScalar8(
+  src: Uint8Array,
+  ip: number,
+  count: number,
+  dst: Uint8Array,
+  dstOff: number,
+  startRef: Uint32Array, // [0] = current start
+  isZigzag: boolean
+): number {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+    const mainBits = b & 0x3f;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    let v = 0;
+    for (let j = 0; j < bytesNeeded; j++) v |= src[ip + j] << (j * 8);
+    if (mainBits < 16) v &= (1 << mainBits) - 1;
+    v &= 0xffff;
+    ip += bytesNeeded;
+    let s = startRef[0];
+    if (isZigzag) {
+      const delta = zigzagdec16(v) & 0xff;
+      for (let i = 0; i < count; i++) {
+        s = (s + delta) & 0xff;
+        dst[dstOff + i] = s;
+      }
+    } else {
+      for (let i = 0; i < count; i++) {
+        s = (s + v) & 0xff;
+        dst[dstOff + i] = s;
+      }
+    }
+    startRef[0] = s;
+    return ip - ipStart;
+  }
+
+  if (!(b & 0x40)) {
+    const mainBits = b & 0x3f;
+    if (b & 0x80) {
+      // Bitmap exceptions
+      const bx = src[ip++];
+      for (let j = 0; j < 16; j++) _bitmapBuf[j] = src[ip + j];
+      ip += 16;
+      let nEx = 0;
+      for (let j = 0; j < 16; j++) {
+        let by = _bitmapBuf[j];
+        while (by) {
+          nEx++;
+          by &= by - 1;
+        }
+      }
+      ip += bitunpackHoriz8(src, ip, nEx, bx, _tmp8, CSIZE); // store exceptions after main area
+      const mainBytes = bitunpackHoriz8(src, ip, count, mainBits, _tmp8, 0);
+      ip += mainBytes;
+      // Merge exceptions
+      let k = 0;
+      for (let j = 0; j < 16; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          const ctz = 31 - Math.clz32(byte & -byte);
+          const pos = j * 8 + ctz;
+          if (pos < count) _tmp8[pos] = (_tmp8[pos] + (_tmp8[CSIZE + k] << mainBits)) & 0xff;
+          k++;
+          byte &= byte - 1;
+        }
+      }
+    } else {
+      const mainBytes = bitunpackHoriz8(src, ip, count, mainBits, _tmp8, 0);
+      ip += mainBytes;
+    }
+  } else {
+    // Variable-byte exceptions
+    const mainBits = b & 0x3f;
+    const bxCount = src[ip++];
+    const mainBytes = bitunpackHoriz8(src, ip, count, mainBits, _tmp8, 0);
+    ip += mainBytes;
+    ip = vbdec32(src, ip, bxCount, _ex8, 0);
+    for (let j = 0; j < bxCount; j++) {
+      const pos = src[ip + j];
+      if (pos < count) _tmp8[pos] = (_tmp8[pos] | (_ex8[j] << mainBits)) & 0xff;
+    }
+    ip += bxCount;
+  }
+
+  let s = startRef[0];
+  if (isZigzag) {
+    for (let i = 0; i < count; i++) {
+      s = (s + zigzagdec16(_tmp8[i])) & 0xff;
+      dst[dstOff + i] = s;
+    }
+  } else {
+    for (let i = 0; i < count; i++) {
+      s = (s + _tmp8[i]) & 0xff;
+      dst[dstOff + i] = s;
+    }
+  }
+  startRef[0] = s;
+  return ip - ipStart;
+}
+
+const _startRef8 = new Uint32Array(1);
+
+/**
+ * Zigzag-delta PFor decode, scalar horizontal format, 8-bit.
+ * Returns bytes consumed.
+ */
+export function p4nzdec8(src: Uint8Array, srcOff: number, n: number, dst: Uint8Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+  // For 8-bit, first value is stored as a single raw byte (vbxget8 = just read 1 byte)
+  const startVal = src[ip++];
+  dst[dstOff] = startVal;
+  _startRef8[0] = startVal;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  while (remaining > 0) {
+    const count = Math.min(remaining, CSIZE);
+    ip += decodeBlockScalar8(src, ip, count, dst, op, _startRef8, true);
+    op += count;
+    remaining -= count;
+  }
+  return ip - srcOff;
+}
+
+/**
+ * Delta PFor decode, scalar horizontal format, 8-bit.
+ * Returns bytes consumed.
+ */
+export function p4nddec8(src: Uint8Array, srcOff: number, n: number, dst: Uint8Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+  const startVal = src[ip++];
+  dst[dstOff] = startVal;
+  _startRef8[0] = startVal;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  while (remaining > 0) {
+    const count = Math.min(remaining, CSIZE);
+    ip += decodeBlockScalar8(src, ip, count, dst, op, _startRef8, false);
+    op += count;
+    remaining -= count;
+  }
+  return ip - srcOff;
+}
+
+// BigInt temp buffers for 64-bit
+const _tmp64_BN = new BigUint64Array(CSIZE + 8);
+const _ex64_BN = new BigUint64Array(CSIZE + 8);
+
+/**
+ * Zigzag-delta PFor decode, scalar horizontal format, 64-bit.
+ * Used for LUT decompression when needed, and Int64Array types.
+ * Returns bytes consumed.
+ */
+export function p4nzdec64(
+  src: Uint8Array,
+  srcOff: number,
+  n: number,
+  dst: BigUint64Array | BigInt64Array,
+  dstOff: number
+): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+  const [startVal, newIp] = vbxget64(src, ip);
+  ip = newIp;
+  dst[dstOff] = startVal;
+  let start = startVal;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  const MASK64 = 0xffffffffffffffffn;
+
+  while (remaining > 0) {
+    const count = Math.min(remaining, CSIZE);
+    const b = src[ip++];
+
+    if ((b & 0xc0) === 0xc0) {
+      // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+      let mainBits = b & 0x3f;
+      if (mainBits === 63) mainBits = 64;
+      let u = 0n;
+      const bytesNeeded = (mainBits + 7) >> 3;
+      for (let j = 0; j < bytesNeeded; j++) {
+        u |= BigInt(src[ip + j]) << BigInt(j * 8);
+      }
+      if (mainBits < 64) u &= (1n << BigInt(mainBits)) - 1n;
+      ip += bytesNeeded;
+      const delta = zigzagdec64(u);
+      for (let i = 0; i < count; i++) {
+        start = (start + delta) & MASK64;
+        dst[op + i] = start;
+      }
+    } else if (!(b & 0x40)) {
+      // PFOR bitpack (with optional exceptions)
+      const mainBits = (b & 0x3f) === 63 ? 64 : b & 0x3f; // 63 stored means 64 for 64-bit
+      let bx = 0;
+      let hasExceptions = false;
+
+      if (b & 0x80) {
+        bx = src[ip++];
+        hasExceptions = true;
+        const p4dn = (count + 7) >> 3;
+        let nEx = 0;
+        for (let j = 0; j < p4dn; j++) {
+          let byte = src[ip + j];
+          if (j === p4dn - 1 && (count & 7) !== 0) byte &= (1 << (count & 7)) - 1;
+          _bitmapBuf[j] = byte;
+          while (byte) {
+            nEx++;
+            byte &= byte - 1;
+          }
+        }
+        ip += p4dn;
+        const exBytes = bitunpackHoriz64(src, ip, nEx, bx, _ex64_BN, 0);
+        ip += exBytes;
+      }
+
+      const mainBytes = bitunpackHoriz64(src, ip, count, mainBits, _tmp64_BN, 0);
+      ip += mainBytes;
+
+      if (hasExceptions) {
+        const p4dn = (count + 7) >> 3;
+        let k = 0;
+        for (let j = 0; j < p4dn; j++) {
+          let byte = _bitmapBuf[j];
+          while (byte) {
+            const ctz = 31 - Math.clz32(byte & -byte);
+            const pos = j * 8 + ctz;
+            if (pos < count) {
+              _tmp64_BN[pos] = (_tmp64_BN[pos] + (_ex64_BN[k] << BigInt(mainBits))) & MASK64;
+            }
+            k++;
+            byte &= byte - 1;
+          }
+        }
+      }
+
+      for (let i = 0; i < count; i++) {
+        start = (start + zigzagdec64(_tmp64_BN[i])) & MASK64;
+        dst[op + i] = start;
+      }
+    } else {
+      // Variable-byte exception mode
+      const mainBits = (b & 0x3f) === 63 ? 64 : b & 0x3f; // 63 stored means 64 for 64-bit
+      const bx = src[ip++];
+      const mainBytes = bitunpackHoriz64(src, ip, count, mainBits, _tmp64_BN, 0);
+      ip += mainBytes;
+      ip = vbdec32(src, ip, bx, _ex32, 0); // positions
+      for (let j = 0; j < bx; j++) {
+        const pos = src[ip + j];
+        if (pos < count) _tmp64_BN[pos] = (_tmp64_BN[pos] | (_ex64_BN[j] << BigInt(mainBits))) & MASK64;
+      }
+      ip += bx;
+      for (let i = 0; i < count; i++) {
+        start = (start + zigzagdec64(_tmp64_BN[i])) & MASK64;
+        dst[op + i] = start;
+      }
+    }
+
+    op += count;
+    remaining -= count;
+  }
+
+  return ip - srcOff;
+}
+
+/**
+ * Delta PFor decode, scalar horizontal format, 64-bit.
+ * Used in om_decoder for LUT decompression (p4nddec64).
+ * Returns bytes consumed.
+ */
+export function p4nddec64(src: Uint8Array, srcOff: number, n: number, dst: BigUint64Array, dstOff: number): number {
+  if (n === 0) return 0;
+  let ip = srcOff;
+  const [startVal, newIp] = vbxget64(src, ip);
+  ip = newIp;
+  dst[dstOff] = startVal;
+  let start = startVal;
+  let remaining = n - 1;
+  let op = dstOff + 1;
+
+  const MASK64 = 0xffffffffffffffffn;
+
+  while (remaining > 0) {
+    const count = Math.min(remaining, CSIZE);
+    const b = src[ip++];
+
+    if ((b & 0xc0) === 0xc0) {
+      // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+      let mainBits = b & 0x3f;
+      if (mainBits === 63) mainBits = 64;
+      let u = 0n;
+      const bytesNeeded = (mainBits + 7) >> 3;
+      for (let j = 0; j < bytesNeeded; j++) {
+        u |= BigInt(src[ip + j]) << BigInt(j * 8);
+      }
+      if (mainBits < 64) u &= (1n << BigInt(mainBits)) - 1n;
+      ip += bytesNeeded;
+      for (let i = 0; i < count; i++) {
+        start = (start + u) & MASK64;
+        dst[op + i] = start;
+      }
+    } else {
+      // PFOR bitpack with optional exceptions (no zigzag)
+      const mainBits = (b & 0x3f) === 63 ? 64 : b & 0x3f; // 63 stored means 64 for 64-bit
+      let bx = 0;
+      let hasExceptions = false;
+
+      if (b & 0x80) {
+        bx = src[ip++];
+        hasExceptions = true;
+        const p4dn = (count + 7) >> 3;
+        let nEx = 0;
+        for (let j = 0; j < p4dn; j++) {
+          let byte = src[ip + j];
+          if (j === p4dn - 1 && (count & 7) !== 0) byte &= (1 << (count & 7)) - 1;
+          _bitmapBuf[j] = byte;
+          while (byte) {
+            nEx++;
+            byte &= byte - 1;
+          }
+        }
+        ip += p4dn;
+        const exBytes = bitunpackHoriz64(src, ip, nEx, bx, _ex64_BN, 0);
+        ip += exBytes;
+      }
+
+      const mainBytes = bitunpackHoriz64(src, ip, count, mainBits, _tmp64_BN, 0);
+      ip += mainBytes;
+
+      if (hasExceptions) {
+        const p4dn = (count + 7) >> 3;
+        let k = 0;
+        for (let j = 0; j < p4dn; j++) {
+          let byte = _bitmapBuf[j];
+          while (byte) {
+            const ctz = 31 - Math.clz32(byte & -byte);
+            const pos = j * 8 + ctz;
+            if (pos < count) {
+              _tmp64_BN[pos] = (_tmp64_BN[pos] + (_ex64_BN[k] << BigInt(mainBits))) & MASK64;
+            }
+            k++;
+            byte &= byte - 1;
+          }
+        }
+      }
+
+      for (let i = 0; i < count; i++) {
+        start = (start + _tmp64_BN[i]) & MASK64;
+        dst[op + i] = start;
+      }
+    }
+
+    op += count;
+    remaining -= count;
+  }
+
+  return ip - srcOff;
+}
+
+// ─── Raw block decoders for fpxdec (no delta, no start value) ─────────────
+
+/**
+ * Decode one block of n <= 128 unsigned 32-bit values.
+ * For n === CSIZE: uses 128v vertical format. Otherwise: scalar horizontal.
+ * No delta or zigzag. Returns bytes consumed.
+ */
+export function p4dec128v32_block(src: Uint8Array, ip: number, n: number, dst: Uint32Array, dstOff: number): number {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+    const mainBits = b & 0x3f;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    let v = 0;
+    for (let j = 0; j < bytesNeeded; j++) v |= src[ip + j] << (j * 8);
+    if (mainBits < 32) v &= (1 << mainBits) - 1;
+    v >>>= 0;
+    ip += bytesNeeded;
+    for (let i = 0; i < n; i++) dst[dstOff + i] = v;
+    return ip - ipStart;
+  }
+
+  if (!(b & 0x40)) {
+    const mainBits = b & 0x3f;
+    if (b & 0x80) {
+      const bx = src[ip++];
+      for (let j = 0; j < 16; j++) _bitmapBuf[j] = src[ip + j];
+      ip += 16;
+      let nEx = 0;
+      for (let j = 0; j < 16; j++) {
+        let by = _bitmapBuf[j];
+        while (by) {
+          nEx++;
+          by &= by - 1;
+        }
+      }
+      const exBytes = bitunpackHoriz32(src, ip, nEx, bx, _ex32, 0);
+      ip += exBytes;
+      if (n === CSIZE) {
+        bitunpackVert32(src, ip, mainBits, _tmp32, 0, n);
+        ip += mainBits * 16;
+      } else {
+        ip += bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
+      }
+      let k = 0;
+      for (let j = 0; j < 16; j++) {
+        let byte = _bitmapBuf[j];
+        while (byte) {
+          const ctz = 31 - Math.clz32(byte & -byte);
+          const pos = j * 8 + ctz;
+          if (pos < n) _tmp32[pos] = (_tmp32[pos] + (_ex32[k] << mainBits)) >>> 0;
+          k++;
+          byte &= byte - 1;
+        }
+      }
+    } else {
+      if (n === CSIZE) {
+        bitunpackVert32(src, ip, mainBits, _tmp32, 0, n);
+        ip += mainBits * 16;
+      } else {
+        ip += bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
+      }
+    }
+    for (let i = 0; i < n; i++) dst[dstOff + i] = _tmp32[i];
+    return ip - ipStart;
+  }
+
+  {
+    const mainBits = b & 0x3f;
+    const bxCount = src[ip++];
+    ip += bitunpackHoriz32(src, ip, n, mainBits, _tmp32, 0);
+    ip = vbdec32(src, ip, bxCount, _ex32, 0);
+    for (let j = 0; j < bxCount; j++) {
+      const pos = src[ip + j];
+      if (pos < n) _tmp32[pos] = (_tmp32[pos] | (_ex32[j] << mainBits)) >>> 0;
+    }
+    ip += bxCount;
+    for (let i = 0; i < n; i++) dst[dstOff + i] = _tmp32[i];
+    return ip - ipStart;
+  }
+}
+
+/**
+ * Decode one block of n <= 128 unsigned 64-bit values using scalar horizontal format.
+ * No delta or zigzag. Returns bytes consumed.
+ */
+export function p4dec64_block(src: Uint8Array, ip: number, n: number, dst: BigUint64Array, dstOff: number): number {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    // RLE: b & 0x3f gives bit-width, value stored as raw bytes (NOT vbxget)
+    let mainBits = b & 0x3f;
+    if (mainBits === 63) mainBits = 64;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    let v = 0n;
+    for (let j = 0; j < bytesNeeded; j++) v |= BigInt(src[ip + j]) << BigInt(j * 8);
+    if (mainBits < 64) v &= (1n << BigInt(mainBits)) - 1n;
+    ip += bytesNeeded;
+    for (let i = 0; i < n; i++) dst[dstOff + i] = v;
+    return ip - ipStart;
+  }
+
+  const mainBits = b === 0x3f ? 64 : b & 0x3f;
+  ip += bitunpackHoriz64(src, ip, n, mainBits, _tmp64_BN, 0);
+  for (let i = 0; i < n; i++) dst[dstOff + i] = _tmp64_BN[i];
+  return ip - ipStart;
+}

--- a/packages/file-format/src/turbopfor.ts
+++ b/packages/file-format/src/turbopfor.ts
@@ -263,11 +263,87 @@ function vbget32_single(src: Uint8Array, offset: number): [number, number] {
   return [val, offset];
 }
 
-// Decode n variable-byte encoded values
+// VB_MAX = 254 → overflow marker is VB_MAX + 1 = 255.
+// When the encoder finds that the variable-byte stream would be larger
+// than just storing raw uint8/uint16/uint32/uint64 values, it writes
+// `0xff` followed by `n * (USIZE / 8)` raw little-endian bytes (the
+// `OVERFLOWE` macro in vint.c).  The decoder counterpart (`OVERFLOWD`)
+// detects this marker and bypasses the VB decode path.
+const VB_OVERFLOW_MARKER = 255;
+
+// Decode n variable-byte encoded values into a Uint8Array (USIZE = 8).
+function vbdec8(src: Uint8Array, offset: number, n: number, dst: Uint8Array | Uint16Array | Uint32Array): number {
+  if (src[offset] === VB_OVERFLOW_MARKER) {
+    offset++;
+    for (let i = 0; i < n; i++) dst[i] = src[offset + i];
+    return offset + n;
+  }
+  for (let i = 0; i < n; i++) {
+    const [v, newOff] = vbget32_single(src, offset);
+    dst[i] = v;
+    offset = newOff;
+  }
+  return offset;
+}
+
+// Decode n variable-byte encoded values into a Uint16Array (USIZE = 16).
+function vbdec16(src: Uint8Array, offset: number, n: number, dst: Uint16Array | Uint32Array): number {
+  if (src[offset] === VB_OVERFLOW_MARKER) {
+    offset++;
+    for (let i = 0; i < n; i++) {
+      dst[i] = src[offset + i * 2] | (src[offset + i * 2 + 1] << 8);
+    }
+    return offset + n * 2;
+  }
+  for (let i = 0; i < n; i++) {
+    const [v, newOff] = vbget32_single(src, offset);
+    dst[i] = v;
+    offset = newOff;
+  }
+  return offset;
+}
+
+// Decode n variable-byte encoded values into a Uint32Array (USIZE = 32).
 function vbdec32(src: Uint8Array, offset: number, n: number, dst: Uint32Array, dstOff: number): number {
+  if (src[offset] === VB_OVERFLOW_MARKER) {
+    offset++;
+    for (let i = 0; i < n; i++) {
+      const b0 = src[offset + i * 4];
+      const b1 = src[offset + i * 4 + 1];
+      const b2 = src[offset + i * 4 + 2];
+      const b3 = src[offset + i * 4 + 3];
+      dst[dstOff + i] = (b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)) >>> 0;
+    }
+    return offset + n * 4;
+  }
   for (let i = 0; i < n; i++) {
     const [v, newOff] = vbget32_single(src, offset);
     dst[dstOff + i] = v;
+    offset = newOff;
+  }
+  return offset;
+}
+
+// Decode n variable-byte encoded values into a Uint32Array, treating each
+// decoded value as the low 32 bits of a 64-bit residual.  USIZE = 64, so the
+// OVERFLOWD path reads 8 raw bytes per element (but only the low 32 bits are
+// stored — the C code does the same when the exception count `bx` is bounded
+// and values are known to fit, see the b + bx <= 32 constraint in vp4d.c).
+function vbdec64_lo32(src: Uint8Array, offset: number, n: number, dst: Uint32Array): number {
+  if (src[offset] === VB_OVERFLOW_MARKER) {
+    offset++;
+    for (let i = 0; i < n; i++) {
+      const b0 = src[offset + i * 8];
+      const b1 = src[offset + i * 8 + 1];
+      const b2 = src[offset + i * 8 + 2];
+      const b3 = src[offset + i * 8 + 3];
+      dst[i] = (b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)) >>> 0;
+    }
+    return offset + n * 8;
+  }
+  for (let i = 0; i < n; i++) {
+    const [v, newOff] = vbget32_single(src, offset);
+    dst[i] = v;
     offset = newOff;
   }
   return offset;
@@ -393,14 +469,13 @@ function decodeBlock128v16(
     bitunpack128v16(src, ip, mainBits, _tmp16, 0);
     ip += mainBits * 16;
 
-    // Decode bx exception values using vb encoding
-    const exDst = _ex16 as unknown as Uint32Array; // reuse buffer
-    ip = vbdec32(src, ip, bx, exDst, 0);
+    // Decode bx exception values using vb encoding (USIZE = 16)
+    ip = vbdec16(src, ip, bx, _ex16);
 
     // Read bx position indices (byte values)
     for (let j = 0; j < bx; j++) {
       const pos = src[ip + j];
-      _tmp16[pos] = (_tmp16[pos] | (exDst[j] << mainBits)) & 0xffff;
+      _tmp16[pos] = (_tmp16[pos] | (_ex16[j] << mainBits)) & 0xffff;
     }
     ip += bx;
 
@@ -526,11 +601,10 @@ function decodePartialBlock16(
     const bx = src[ip++];
     const mainBytes = bitunpackHoriz16(src, ip, n, mainBits, _tmp16, 0);
     ip += mainBytes;
-    const exDst = _ex16 as unknown as Uint32Array;
-    ip = vbdec32(src, ip, bx, exDst, 0);
+    ip = vbdec16(src, ip, bx, _ex16);
     for (let j = 0; j < bx; j++) {
       const pos = src[ip + j];
-      if (pos < n) _tmp16[pos] = (_tmp16[pos] | (exDst[j] << mainBits)) & 0xffff;
+      if (pos < n) _tmp16[pos] = (_tmp16[pos] | (_ex16[j] << mainBits)) & 0xffff;
     }
     ip += bx;
     let s = startArr[0];
@@ -875,6 +949,11 @@ function _traceBlock16(src: Uint8Array, ip: number, n: number): { type: string; 
   // vbdec: count bytes for bx values
   let vbBytes = 0;
   const tempIp = ip + mainBytes;
+  if (src[tempIp] === VB_OVERFLOW_MARKER) {
+    // OVERFLOWD path: 1 marker byte + bx * 2 raw uint16 bytes (USIZE = 16)
+    vbBytes = 1 + bx * 2;
+    return { type: `VBex(mainBits=${mainBits},bx=${bx},overflow)`, bytes: 2 + mainBytes + vbBytes + bx };
+  }
   for (let j = 0; j < bx; j++) {
     const x = src[tempIp + vbBytes++];
     if (x >= 177 && x < 241)
@@ -1119,7 +1198,7 @@ function decodeBlockScalar8(
     const bxCount = src[ip++];
     const mainBytes = bitunpackHoriz8(src, ip, count, mainBits, _tmp8, 0);
     ip += mainBytes;
-    ip = vbdec32(src, ip, bxCount, _ex8, 0);
+    ip = vbdec8(src, ip, bxCount, _ex8);
     for (let j = 0; j < bxCount; j++) {
       const pos = src[ip + j];
       if (pos < count) _tmp8[pos] = (_tmp8[pos] | (_ex8[j] << mainBits)) & 0xff;
@@ -1291,7 +1370,7 @@ export function p4nzdec64(
       const bx = src[ip++];
       const mainBytes = bitunpackHoriz64(src, ip, count, mainBits, _tmp64_BN, 0);
       ip += mainBytes;
-      ip = vbdec32(src, ip, bx, _ex32, 0); // exception values (32-bit residuals above mainBits)
+      ip = vbdec64_lo32(src, ip, bx, _ex32); // exception values (32-bit residuals above mainBits)
       for (let j = 0; j < bx; j++) {
         const pos = src[ip + j]; // exception position indices
         if (pos < count) _tmp64_BN[pos] = (_tmp64_BN[pos] | (BigInt(_ex32[j] >>> 0) << BigInt(mainBits))) & MASK64;
@@ -1400,7 +1479,7 @@ export function p4nddec64(src: Uint8Array, srcOff: number, n: number, dst: BigUi
       const bx = src[ip++]; // number of exceptions
       const mainBytes = bitunpackHoriz64(src, ip, count, mainBits, _tmp64_BN, 0);
       ip += mainBytes;
-      ip = vbdec32(src, ip, bx, _ex32, 0); // exception values (32-bit residuals above mainBits)
+      ip = vbdec64_lo32(src, ip, bx, _ex32); // exception values (32-bit residuals above mainBits)
       for (let j = 0; j < bx; j++) {
         const pos = src[ip + j]; // exception position indices
         if (pos < count) _tmp64_BN[pos] = (_tmp64_BN[pos] | (BigInt(_ex32[j] >>> 0) << BigInt(mainBits))) & MASK64;

--- a/packages/file-format/src/turbopfor.ts
+++ b/packages/file-format/src/turbopfor.ts
@@ -239,7 +239,7 @@ const VB_BA3 = 249;
 const VB_OFS2 = 16561;
 
 function vbget32_single(src: Uint8Array, offset: number): [number, number] {
-  let x = src[offset++];
+  const x = src[offset++];
   if (x < VB_OFS1) return [x, offset];
   if (x < VB_BA2) {
     const next = src[offset++];
@@ -322,13 +322,12 @@ function decodeBlock128v16(
 
   if (!(b & 0x40)) {
     // Pure vertical bitpack (b & 0x80 == 0) or bitmap exceptions (b & 0x80 != 0)
-    let mainBits = b & 0x3f;
-    let bx = 0;
+    const mainBits = b & 0x3f;
     let hasExceptions = false;
 
     if (b & 0x80) {
       // Bitmap exceptions
-      bx = src[ip++];
+      const bx = src[ip++];
       hasExceptions = true;
       // Copy 16-byte bitmap
       for (let j = 0; j < 16; j++) _bitmapBuf[j] = src[ip + j];
@@ -356,8 +355,7 @@ function decodeBlock128v16(
       for (let j = 0; j < 16; j++) {
         let byte = _bitmapBuf[j];
         while (byte) {
-          const bitPos = Math.clz32(byte ^ (byte - 1)) ^ 31; // ctz: index of lowest set bit
-          // Actually: ctz = number of trailing zeros
+          // ctz = number of trailing zeros
           const ctz = 31 - Math.clz32(byte & -byte);
           const pos = j * 8 + ctz;
           _tmp16[pos] = (_tmp16[pos] + (_ex16[k++] << mainBits)) & 0xffff;
@@ -462,11 +460,10 @@ function decodePartialBlock16(
 
   if (!(b & 0x40)) {
     const mainBits = b & 0x3f;
-    let bx = 0;
     let hasExceptions = false;
 
     if (b & 0x80) {
-      bx = src[ip++];
+      const bx = src[ip++];
       hasExceptions = true;
       // Scalar partial-block format: ceil(n/8) bytes for position bitmap (1 bit per element)
       const p4dn = (n + 7) >> 3;
@@ -590,11 +587,10 @@ function decodeBlock128v32(
 
   if (!(b & 0x40)) {
     const mainBits = b & 0x3f;
-    let bx = 0;
     let hasExceptions = false;
 
     if (b & 0x80) {
-      bx = src[ip++];
+      const bx = src[ip++];
       hasExceptions = true;
       for (let j = 0; j < 16; j++) _bitmapBuf[j] = src[ip + j];
       ip += 16;
@@ -711,11 +707,10 @@ function decodePartialBlock32(
 
   if (!(b & 0x40)) {
     const mainBits = b & 0x3f;
-    let bx = 0;
     let hasExceptions = false;
 
     if (b & 0x80) {
-      bx = src[ip++];
+      const bx = src[ip++];
       hasExceptions = true;
       // Scalar partial-block format: ceil(n/8) bytes for position bitmap (1 bit per element)
       const p4dn = (n + 7) >> 3;
@@ -1124,11 +1119,10 @@ export function p4nzdec64(
     } else if (!(b & 0x40)) {
       // PFOR bitpack (with optional exceptions)
       const mainBits = (b & 0x3f) === 63 ? 64 : b & 0x3f; // 63 stored means 64 for 64-bit
-      let bx = 0;
       let hasExceptions = false;
 
       if (b & 0x80) {
-        bx = src[ip++];
+        const bx = src[ip++];
         hasExceptions = true;
         const p4dn = (count + 7) >> 3;
         let nEx = 0;
@@ -1234,11 +1228,10 @@ export function p4nddec64(src: Uint8Array, srcOff: number, n: number, dst: BigUi
     } else {
       // PFOR bitpack with optional exceptions (no zigzag)
       const mainBits = (b & 0x3f) === 63 ? 64 : b & 0x3f; // 63 stored means 64 for 64-bit
-      let bx = 0;
       let hasExceptions = false;
 
       if (b & 0x80) {
-        bx = src[ip++];
+        const bx = src[ip++];
         hasExceptions = true;
         const p4dn = (count + 7) >> 3;
         let nEx = 0;

--- a/packages/file-format/src/turbopfor.ts
+++ b/packages/file-format/src/turbopfor.ts
@@ -180,7 +180,7 @@ function bitunpack128v16(src: Uint8Array, offset: number, b: number, dst: Uint16
     const laneBase = offset + lane * 2;
     let bitPos = 0;
     for (let p = 0; p < 16; p++) {
-      const wordIdx = (bitPos >>> 4); // floor(bitPos / 16)
+      const wordIdx = bitPos >>> 4; // floor(bitPos / 16)
       const bitInWord = bitPos & 15;
       const byteOff = laneBase + wordIdx * 16;
       const word0 = src[byteOff] | (src[byteOff + 1] << 8);
@@ -214,14 +214,16 @@ function bitunpack128v32(src: Uint8Array, offset: number, b: number, dst: Uint32
       const wordIdx = (bitPos / 32) | 0;
       const bitInWord = bitPos % 32;
       const byteOff = laneBase + wordIdx * 16;
-      const word0 = (src[byteOff] | (src[byteOff + 1] << 8) | (src[byteOff + 2] << 16) | (src[byteOff + 3] << 24)) >>> 0;
+      const word0 =
+        (src[byteOff] | (src[byteOff + 1] << 8) | (src[byteOff + 2] << 16) | (src[byteOff + 3] << 24)) >>> 0;
       let val: number;
       if (bitInWord === 0) {
         val = (word0 & mask) >>> 0;
       } else if (bitInWord + b <= 32) {
         val = (word0 >>> bitInWord) & mask;
       } else {
-        const word1 = (src[byteOff + 16] | (src[byteOff + 17] << 8) | (src[byteOff + 18] << 16) | (src[byteOff + 19] << 24)) >>> 0;
+        const word1 =
+          (src[byteOff + 16] | (src[byteOff + 17] << 8) | (src[byteOff + 18] << 16) | (src[byteOff + 19] << 24)) >>> 0;
         val = ((word0 >>> bitInWord) | ((word1 << (32 - bitInWord)) >>> 0)) & mask;
       }
       dst[dstOff + p * 4 + lane] = val >>> 0;
@@ -341,7 +343,7 @@ function decodeBlock128v16(
           byte &= byte - 1;
         }
       }
-        // Scalar horizontal unpack exceptions at bx bits
+      // Scalar horizontal unpack exceptions at bx bits
       ip += bitunpackHoriz16(src, ip, nEx, bx, _ex16, 0);
     }
 
@@ -799,6 +801,91 @@ function decodePartialBlock32(
 const _startArr16 = new Int32Array(1);
 const _startArr32 = new Float64Array(1);
 
+// ─── Debug tracing helper (temporary, remove after bug is found) ─────────────
+
+/** Global debug flag: when set, p4nzdec128v16 logs each block's type and byte count. */
+export let _p4n16Debug = false;
+export function enableP4n16Debug(): void {
+  _p4n16Debug = true;
+}
+export function disableP4n16Debug(): void {
+  _p4n16Debug = false;
+}
+
+/** Compute how many bytes a single block at src[ip] will consume WITHOUT decoding it. */
+function _traceBlock16(src: Uint8Array, ip: number, n: number): { type: string; bytes: number } {
+  const ipStart = ip;
+  const b = src[ip++];
+
+  if ((b & 0xc0) === 0xc0) {
+    const mainBits = b & 0x3f;
+    const bytesNeeded = (mainBits + 7) >> 3;
+    return { type: `RLE(bits=${mainBits})`, bytes: 1 + bytesNeeded };
+  }
+
+  if (!(b & 0x40)) {
+    const mainBits = b & 0x3f;
+    let exBytes = 0;
+    let bitmapBytes = 0;
+    if (b & 0x80) {
+      const bx = src[ip++];
+      if (n === CSIZE) {
+        // Full block: 16-byte bitmap
+        bitmapBytes = 16;
+        let nEx = 0;
+        for (let j = 0; j < 16; j++) {
+          let byte = src[ipStart + 2 + j];
+          while (byte) {
+            nEx++;
+            byte &= byte - 1;
+          }
+        }
+        exBytes = Math.ceil((nEx * bx) / 8);
+        ip += 16 + exBytes;
+      } else {
+        // Partial block: ceil(n/8) byte bitmap
+        const p4dn = (n + 7) >> 3;
+        bitmapBytes = p4dn;
+        let nEx = 0;
+        for (let j = 0; j < p4dn; j++) {
+          let byte = src[ip + j];
+          if (j === p4dn - 1 && (n & 7) !== 0) byte &= (1 << (n & 7)) - 1;
+          while (byte) {
+            nEx++;
+            byte &= byte - 1;
+          }
+        }
+        exBytes = Math.ceil((nEx * bx) / 8);
+        ip += p4dn + exBytes;
+      }
+      const mainBytes = n === CSIZE ? mainBits * 16 : Math.ceil((n * mainBits) / 8);
+      return {
+        type: `BitmapEx(mainBits=${mainBits},bx=${bx},nEx?,bitmapBytes=${bitmapBytes})`,
+        bytes: 2 + bitmapBytes + exBytes + mainBytes,
+      };
+    }
+    const mainBytes = n === CSIZE ? mainBits * 16 : Math.ceil((n * mainBits) / 8);
+    return { type: `Bitpack(mainBits=${mainBits})`, bytes: 1 + mainBytes };
+  }
+
+  // VB exception mode
+  const mainBits = b & 0x3f;
+  const bx = src[ip++];
+  const mainBytes = n === CSIZE ? mainBits * 16 : Math.ceil((n * mainBits) / 8);
+  // vbdec: count bytes for bx values
+  let vbBytes = 0;
+  const tempIp = ip + mainBytes;
+  for (let j = 0; j < bx; j++) {
+    const x = src[tempIp + vbBytes++];
+    if (x >= 177 && x < 241)
+      vbBytes++; // 2-byte
+    else if (x >= 241 && x < 249)
+      vbBytes += 2; // 3-byte
+    else if (x >= 249) vbBytes += 2 + (x - 249); // 4+ byte
+  }
+  return { type: `VBex(mainBits=${mainBits},bx=${bx})`, bytes: 2 + mainBytes + vbBytes + bx };
+}
+
 /**
  * Zigzag-delta PFor decode, 128v vertical format, 16-bit.
  * Used for COMPRESSION_PFOR_DELTA2D_INT16.
@@ -817,15 +904,49 @@ export function p4nzdec128v16(src: Uint8Array, srcOff: number, n: number, dst: U
   let op = dstOff + 1;
 
   // Full blocks of CSIZE=128
+  let blockNum = 0;
   while (remaining >= CSIZE) {
-    ip += decodeBlock128v16(src, ip, dst, op, _startArr16, true);
+    const blockIpBefore = ip;
+    if (_p4n16Debug) {
+      const trace = _traceBlock16(src, ip, CSIZE);
+      const consumed = decodeBlock128v16(src, ip, dst, op, _startArr16, true);
+      if (trace.bytes !== consumed) {
+        console.log(
+          `[p4nzdec128v16] MISMATCH block ${blockNum}: trace=${trace.type} expected=${trace.bytes} actual=${consumed} at ip=${blockIpBefore - srcOff}`
+        );
+      } else {
+        console.log(
+          `[p4nzdec128v16] block ${blockNum}: ${trace.type} consumed=${consumed} at ip=${blockIpBefore - srcOff}`
+        );
+      }
+      ip += consumed;
+    } else {
+      ip += decodeBlock128v16(src, ip, dst, op, _startArr16, true);
+    }
     op += CSIZE;
     remaining -= CSIZE;
+    blockNum++;
   }
 
   // Partial final block
   if (remaining > 0) {
-    ip += decodePartialBlock16(src, ip, remaining, dst, op, _startArr16, true);
+    const blockIpBefore = ip;
+    if (_p4n16Debug) {
+      const trace = _traceBlock16(src, ip, remaining);
+      const consumed = decodePartialBlock16(src, ip, remaining, dst, op, _startArr16, true);
+      if (trace.bytes !== consumed) {
+        console.log(
+          `[p4nzdec128v16] MISMATCH partial block ${blockNum} (n=${remaining}): trace=${trace.type} expected=${trace.bytes} actual=${consumed} at ip=${blockIpBefore - srcOff}`
+        );
+      } else {
+        console.log(
+          `[p4nzdec128v16] partial block ${blockNum} (n=${remaining}): ${trace.type} consumed=${consumed} at ip=${blockIpBefore - srcOff}`
+        );
+      }
+      ip += consumed;
+    } else {
+      ip += decodePartialBlock16(src, ip, remaining, dst, op, _startArr16, true);
+    }
   }
 
   return ip - srcOff;
@@ -1170,10 +1291,10 @@ export function p4nzdec64(
       const bx = src[ip++];
       const mainBytes = bitunpackHoriz64(src, ip, count, mainBits, _tmp64_BN, 0);
       ip += mainBytes;
-      ip = vbdec32(src, ip, bx, _ex32, 0); // positions
+      ip = vbdec32(src, ip, bx, _ex32, 0); // exception values (32-bit residuals above mainBits)
       for (let j = 0; j < bx; j++) {
-        const pos = src[ip + j];
-        if (pos < count) _tmp64_BN[pos] = (_tmp64_BN[pos] | (_ex64_BN[j] << BigInt(mainBits))) & MASK64;
+        const pos = src[ip + j]; // exception position indices
+        if (pos < count) _tmp64_BN[pos] = (_tmp64_BN[pos] | (BigInt(_ex32[j] >>> 0) << BigInt(mainBits))) & MASK64;
       }
       ip += bx;
       for (let i = 0; i < count; i++) {
@@ -1225,8 +1346,8 @@ export function p4nddec64(src: Uint8Array, srcOff: number, n: number, dst: BigUi
         start = (start + u) & MASK64;
         dst[op + i] = start;
       }
-    } else {
-      // PFOR bitpack with optional exceptions (no zigzag)
+    } else if (!(b & 0x40)) {
+      // PFOR bitpack with optional bitmap exceptions (no zigzag)
       const mainBits = (b & 0x3f) === 63 ? 64 : b & 0x3f; // 63 stored means 64 for 64-bit
       let hasExceptions = false;
 
@@ -1269,6 +1390,22 @@ export function p4nddec64(src: Uint8Array, srcOff: number, n: number, dst: BigUi
         }
       }
 
+      for (let i = 0; i < count; i++) {
+        start = (start + _tmp64_BN[i]) & MASK64;
+        dst[op + i] = start;
+      }
+    } else {
+      // Variable-byte exception mode (b & 0x40 set, b & 0x80 not set) — no zigzag
+      const mainBits = (b & 0x3f) === 63 ? 64 : b & 0x3f;
+      const bx = src[ip++]; // number of exceptions
+      const mainBytes = bitunpackHoriz64(src, ip, count, mainBits, _tmp64_BN, 0);
+      ip += mainBytes;
+      ip = vbdec32(src, ip, bx, _ex32, 0); // exception values (32-bit residuals above mainBits)
+      for (let j = 0; j < bx; j++) {
+        const pos = src[ip + j]; // exception position indices
+        if (pos < count) _tmp64_BN[pos] = (_tmp64_BN[pos] | (BigInt(_ex32[j] >>> 0) << BigInt(mainBits))) & MASK64;
+      }
+      ip += bx;
       for (let i = 0; i < count; i++) {
         start = (start + _tmp64_BN[i]) & MASK64;
         dst[op + i] = start;

--- a/packages/file-format/src/vbx.ts
+++ b/packages/file-format/src/vbx.ts
@@ -1,0 +1,130 @@
+// vbx.ts — Variable-byte extended (vbxget) encoding used for PFor start values
+//
+// Format (UTF-8-like, big-endian MSBit-flagged):
+//   1 byte  [0x00-0x7F]: value 0..127
+//   2 bytes [0x80-0xBF, byte]: value = (b0&0x3F)<<8 | b1  → 0..16383
+//   3 bytes [0xC0-0xDF, b1, b2]: value = (b0&0x1F)<<16 | b1<<8 | b2  (little-endian b1b2)
+//           actually: value = (b0&0x1F)<<16 | ctou16LE(ptr)  → 0..2097151
+
+// Read a vbx-encoded 32/16-bit unsigned value from src[offset].
+// Returns [value, newOffset].
+export function vbxget32(src: Uint8Array, offset: number): [number, number] {
+  let b = src[offset++];
+  if (!(b & 0x80)) {
+    return [b, offset];
+  }
+  if (!(b & 0x40)) {
+    // 2-byte: bswap16(ctou16(ptr-1) & 0xff3f)
+    // = (src[offset] & 0xff) | ((b & 0x3f) << 8)
+    const next = src[offset++];
+    return [((b & 0x3f) << 8) | next, offset];
+  }
+  if (!(b & 0x20)) {
+    // 3-byte: (b & 0x1f) << 16 | ctou16LE(ptr)
+    const lo = src[offset] | (src[offset + 1] << 8);
+    offset += 2;
+    return [((b & 0x1f) << 16) | lo, offset];
+  }
+  if (!(b & 0x10)) {
+    // 4-byte: bswap32(ctou32(ptr-1) & 0xffffff0f)
+    const b1 = src[offset++];
+    const b2 = src[offset++];
+    const b3 = src[offset++];
+    // bswap32(ctou32le(ptr-1) & 0xffffff0f)
+    // ctou32le(ptr-1) = b | b1<<8 | b2<<16 | b3<<24
+    // & 0xffffff0f: clears bits 4-7 (the top 4 bits of b which are 1110)
+    // bswap32: result = b3 | b2<<8 | b1<<16 | (b&0x0f)<<24
+    return [b3 | (b2 << 8) | (b1 << 16) | ((b & 0x0f) << 24), offset];
+  }
+  // 5-byte: (b & 0x07) << 32 | ctou32LE(ptr) — for 32-bit this truncates to 32 bits
+  const lo32 = (src[offset] | (src[offset + 1] << 8) | (src[offset + 2] << 16) | (src[offset + 3] << 24)) >>> 0;
+  offset += 4;
+  return [lo32, offset]; // upper bits (b & 0x07) lost for 32-bit context
+}
+
+// vbxget16 uses the same format as vbxget32
+export const vbxget16 = vbxget32;
+
+// vbxget64: returns BigInt for 64-bit values
+export function vbxget64(src: Uint8Array, offset: number): [bigint, number] {
+  let b = src[offset++];
+  if (!(b & 0x80)) {
+    return [BigInt(b), offset];
+  }
+  if (!(b & 0x40)) {
+    // 2-byte: bswap16(ctou16(ptr-1) & 0xff3f)
+    const next = src[offset++];
+    return [BigInt(((b & 0x3f) << 8) | next), offset];
+  }
+  if (!(b & 0x20)) {
+    // 3-byte: (b & 0x1f) << 16 | ctou16LE(ptr)
+    const lo = src[offset] | (src[offset + 1] << 8);
+    offset += 2;
+    return [BigInt(((b & 0x1f) << 16) | lo), offset];
+  }
+  if (!(b & 0x10)) {
+    // 4-byte: bswap32(ctou32(ptr-1) & 0xffffff0f)
+    const b1 = src[offset++];
+    const b2 = src[offset++];
+    const b3 = src[offset++];
+    return [BigInt(b3 | (b2 << 8) | (b1 << 16) | ((b & 0x0f) << 24)), offset];
+  }
+  if (!(b & 0x08)) {
+    // 5-byte: (b & 0x07) << 32 | ctou32LE(ptr)
+    const lo32 = (src[offset] | (src[offset + 1] << 8) | (src[offset + 2] << 16) | (src[offset + 3] << 24)) >>> 0;
+    offset += 4;
+    return [BigInt(b & 0x07) * 0x100000000n + BigInt(lo32), offset];
+  }
+  if (!(b & 0x04)) {
+    // 6-byte: (bswap16(ctou16(ip-1)) & 0x7ff) << 32 | ctou32(ip+1); ip += 5
+    // ctou16(ip-1) = b | (src[offset] << 8), bswap16 = src[offset] | (b << 8), & 0x7ff
+    const hiPart = src[offset] | ((b & 0x03) << 8); // 10-bit value
+    offset++; // skip first byte of the pair
+    const lo32 = (src[offset] | (src[offset + 1] << 8) | (src[offset + 2] << 16) | (src[offset + 3] << 24)) >>> 0;
+    offset += 4;
+    return [BigInt(hiPart) * 0x100000000n + BigInt(lo32), offset];
+  }
+  if (!(b & 0x02)) {
+    // 7-byte: (b & 0x03) << 48 | ctou16LE(ip) << 32 | ctou32LE(ip+2); ip += 6
+    const hi16 = (src[offset] | (src[offset + 1] << 8)) >>> 0;
+    const lo32 = (src[offset + 2] | (src[offset + 3] << 8) | (src[offset + 4] << 16) | (src[offset + 5] << 24)) >>> 0;
+    offset += 6;
+    return [(BigInt(b & 0x03) << 48n) | (BigInt(hi16) << 32n) | BigInt(lo32), offset];
+  }
+  if (!(b & 0x01)) {
+    // 8-byte: bswap64(ctou64(ip-1)) & 0x01ffffffffffffff; ip += 7
+    // ctou64(ip-1) reads 8 bytes starting from b (LE), bswap64 reverses them
+    // Result = high bits from first byte after masking, then 6 more bytes
+    const b7 = src[offset + 6];
+    const b6 = src[offset + 5];
+    const b5 = src[offset + 4];
+    const b4 = src[offset + 3];
+    const b3 = src[offset + 2];
+    const b2 = src[offset + 1];
+    const b1 = src[offset + 0];
+    // bswap64 of [b, b1, b2, b3, b4, b5, b6, b7] = [b7, b6, b5, b4, b3, b2, b1, b] & 0x01ff...
+    const hi = ((b7 & 0x01) << 24) | (b6 << 16) | (b5 << 8) | b4;
+    const lo = (b3 << 24) | (b2 << 16) | (b1 << 8) | b;
+    // Actually: bswap64(ctou64(ip-1)) gives the 8 bytes reversed
+    // ctou64LE(ip-1) = b + b1<<8 + ... + b7<<56
+    // bswap64 = b7 + b6<<8 + ... + b<<56
+    // & 0x01ffffffffffffff = (b<<56 + ... + b7) & mask → upper byte masked to 0x01
+    // This is complex - let's use a simpler approach
+    const val =
+      (BigInt(b & 0x01) << 56n) |
+      (BigInt(b1) << 48n) |
+      (BigInt(b2) << 40n) |
+      (BigInt(b3) << 32n) |
+      (BigInt(b4) << 24n) |
+      (BigInt(b5) << 16n) |
+      (BigInt(b6) << 8n) |
+      BigInt(b7);
+    offset += 7;
+    return [val, offset];
+  }
+  // 9-byte (b = 0xff): next 8 bytes are the value LE
+  const lo32 = (src[offset] | (src[offset + 1] << 8) | (src[offset + 2] << 16) | (src[offset + 3] << 24)) >>> 0;
+  const hi32 = (src[offset + 4] | (src[offset + 5] << 8) | (src[offset + 6] << 16) | (src[offset + 7] << 24)) >>> 0;
+  offset += 8;
+  return [BigInt(hi32) * 0x100000000n + BigInt(lo32), offset];
+}

--- a/packages/file-format/src/vbx.ts
+++ b/packages/file-format/src/vbx.ts
@@ -9,7 +9,7 @@
 // Read a vbx-encoded 32/16-bit unsigned value from src[offset].
 // Returns [value, newOffset].
 export function vbxget32(src: Uint8Array, offset: number): [number, number] {
-  let b = src[offset++];
+  const b = src[offset++];
   if (!(b & 0x80)) {
     return [b, offset];
   }
@@ -47,7 +47,7 @@ export const vbxget16 = vbxget32;
 
 // vbxget64: returns BigInt for 64-bit values
 export function vbxget64(src: Uint8Array, offset: number): [bigint, number] {
-  let b = src[offset++];
+  const b = src[offset++];
   if (!(b & 0x80)) {
     return [BigInt(b), offset];
   }
@@ -103,8 +103,6 @@ export function vbxget64(src: Uint8Array, offset: number): [bigint, number] {
     const b2 = src[offset + 1];
     const b1 = src[offset + 0];
     // bswap64 of [b, b1, b2, b3, b4, b5, b6, b7] = [b7, b6, b5, b4, b3, b2, b1, b] & 0x01ff...
-    const hi = ((b7 & 0x01) << 24) | (b6 << 16) | (b5 << 8) | b4;
-    const lo = (b3 << 24) | (b2 << 16) | (b1 << 8) | b;
     // Actually: bswap64(ctou64(ip-1)) gives the 8 bytes reversed
     // ctou64LE(ip-1) = b + b1<<8 + ... + b7<<56
     // bswap64 = b7 + b6<<8 + ... + b<<56

--- a/packages/file-format/tsconfig.build.json
+++ b/packages/file-format/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["es2022", "dom"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/file-format/tsconfig.json
+++ b/packages/file-format/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "lib": ["es2022"],
+    "strict": true,
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/file-format/tsconfig.json
+++ b/packages/file-format/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "esnext",
-    "lib": ["es2022"],
+    "lib": ["es2022", "dom"],
     "strict": true,
     "moduleResolution": "bundler",
     "noEmit": true,

--- a/packages/file-reader/package.json
+++ b/packages/file-reader/package.json
@@ -42,7 +42,7 @@
     "vitest": "^4.0.5"
   },
   "dependencies": {
-    "@openmeteo/file-format-wasm": "^0.0.16"
+    "@openmeteo/file-format": "*"
   },
   "files": [
     "dist/**/*"

--- a/packages/file-reader/rollup.config.js
+++ b/packages/file-reader/rollup.config.js
@@ -7,6 +7,8 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const commonPlugins = [resolve(), commonjs(), typescript({ tsconfig: "./tsconfig.json" }), isProduction && terser()];
 
+const external = ["@openmeteo/file-format-wasm", "@openmeteo/file-format"];
+
 export default [
   // Browser ESM
   {
@@ -17,7 +19,7 @@ export default [
       sourcemap: true,
       inlineDynamicImports: true,
     },
-    external: ["@openmeteo/file-format-wasm"],
+    external,
     plugins: commonPlugins,
   },
   // Node ESM
@@ -29,7 +31,7 @@ export default [
       sourcemap: true,
       inlineDynamicImports: true,
     },
-    external: ["@openmeteo/file-format-wasm"],
+    external,
     plugins: commonPlugins,
   },
   // Browser CJS
@@ -41,7 +43,7 @@ export default [
       sourcemap: true,
       inlineDynamicImports: true,
     },
-    external: ["@openmeteo/file-format-wasm"],
+    external,
     plugins: commonPlugins,
   },
   // Node CJS
@@ -53,25 +55,28 @@ export default [
       sourcemap: true,
       inlineDynamicImports: true,
     },
-    external: ["@openmeteo/file-format-wasm"],
+    external,
     plugins: commonPlugins,
   },
   // Type definitions - Browser-only
   {
     input: "src/index.browser.ts",
     output: { file: "dist/index.browser.d.ts", format: "es" },
+    external,
     plugins: [dts()],
   },
   // Type definitions - Node-only
   {
     input: "src/index.node.ts",
     output: { file: "dist/index.node.d.ts", format: "es" },
+    external,
     plugins: [dts()],
   },
   // Combined fallback
   {
     input: "src/index.types.ts",
     output: { file: "dist/index.d.ts", format: "es" },
+    external,
     plugins: [dts()],
   },
 ];

--- a/packages/file-reader/src/lib/OmFileReader.ts
+++ b/packages/file-reader/src/lib/OmFileReader.ts
@@ -303,7 +303,7 @@ export class OmFileReader {
       async (dataRead) => {
         totalDataReads++;
         const data = await this.backend.getBytes(dataRead.offset, dataRead.count, signal);
-        const error = omDecodeChunks(decoder, dataRead.chunkIndex, data, output as any, chunkBuf);
+        const error = omDecodeChunks(decoder, dataRead.chunkIndex, data, output as Parameters<typeof omDecodeChunks>[3], chunkBuf);
         if (error !== OmError.Ok) {
           console.error(
             `[OmFileReader] omDecodeChunks error=${error} at dataRead #${totalDataReads}: offset=${dataRead.offset} count=${dataRead.count} chunkIndex=[${dataRead.chunkIndex.lowerBound},${dataRead.chunkIndex.upperBound})`

--- a/packages/file-reader/src/lib/OmFileReader.ts
+++ b/packages/file-reader/src/lib/OmFileReader.ts
@@ -10,30 +10,36 @@ import {
   OmFilePrefetchReadOptions,
 } from "./types";
 import { runLimited, throwIfAborted } from "./utils";
-import { WasmModule, initWasm, getWasmModule } from "./wasm";
+import {
+  omHeaderType,
+  omTrailerRead,
+  OmHeaderType,
+  OmVariable,
+  OmCompression,
+  OmError,
+  omDecoderInit,
+  omInitIndexRead,
+  omInitDataRead,
+  omNextIndexRead,
+  omNextDataRead,
+  omDecodeChunks,
+  omDecoderReadBufferSize,
+} from "@openmeteo/file-format";
+import { OM_TRAILER_SIZE, OM_HEADER_V1_SIZE } from "@openmeteo/file-format";
 
 export class OmFileReader {
   private backend: OmFileReaderBackend;
-  private wasm: WasmModule;
-  private variable: number | null;
-  private variableDataPtr: number | null;
+  private variable: OmVariable | null;
   private metadataCache: Map<string, OffsetSize | null>;
 
-  constructor(backend: OmFileReaderBackend, wasm?: WasmModule) {
+  constructor(backend: OmFileReaderBackend, _wasm?: unknown) {
     this.backend = backend;
-    this.wasm = wasm || getWasmModule();
     this.variable = null;
-    this.variableDataPtr = null;
     this.metadataCache = new Map();
   }
 
-  /**
-   * Static factory method to create and initialize an OmFileReader
-   */
   static async create(backend: OmFileReaderBackend): Promise<OmFileReader> {
-    // Make sure WASM is initialized
-    const wasm = await initWasm();
-    const reader = new OmFileReader(backend, wasm);
+    const reader = new OmFileReader(backend);
     await reader.initialize();
     return reader;
   }
@@ -41,50 +47,20 @@ export class OmFileReader {
   async initialize(): Promise<OmFileReader> {
     let variableData: Uint8Array | undefined;
 
-    // First, try to read the trailer
-    const trailerSize = this.wasm.om_trailer_size();
-
     const fileSize = await this.backend.count();
-    if (fileSize < trailerSize) {
-      throw new Error("File too small to contain trailer");
-    }
-
-    if (fileSize >= trailerSize) {
-      const trailerOffset = fileSize - trailerSize;
-      const trailerPtr = await this._readDataBlock(trailerOffset, trailerSize);
-
-      const offsetPtr = this.wasm._malloc(8); // 64-bit value
-      const sizePtr = this.wasm._malloc(8);
-
-      try {
-        const success = this.wasm.om_trailer_read(trailerPtr, offsetPtr, sizePtr);
-
-        if (success) {
-          const offset = Number(this.wasm.getValue(offsetPtr, "i64"));
-          const size = Number(this.wasm.getValue(sizePtr, "i64"));
-          variableData = await this.backend.getBytes(offset, size);
-        }
-      } finally {
-        this.wasm._free(trailerPtr);
-        this.wasm._free(offsetPtr);
-        this.wasm._free(sizePtr);
+    if (fileSize >= OM_TRAILER_SIZE) {
+      const trailerBytes = await this.backend.getBytes(fileSize - OM_TRAILER_SIZE, OM_TRAILER_SIZE);
+      const parsed = omTrailerRead(trailerBytes);
+      if (parsed) {
+        variableData = await this.backend.getBytes(Number(parsed.offset), Number(parsed.size));
       }
     }
 
-    // Fallback to legacy header if trailer reading fails
     if (!variableData) {
-      const headerSize = this.wasm.om_header_size();
-      const headerData = await this.backend.getBytes(0, headerSize);
-      const headerPtr = this.wasm._malloc(headerData.length);
-      this.wasm.HEAPU8.set(headerData, headerPtr);
-
-      try {
-        const headerType = this.wasm.om_header_type(headerPtr);
-        if (headerType === this.wasm.OM_HEADER_LEGACY) {
-          variableData = headerData;
-        }
-      } finally {
-        this.wasm._free(headerPtr);
+      const headerBytes = await this.backend.getBytes(0, OM_HEADER_V1_SIZE);
+      const headerType = omHeaderType(headerBytes);
+      if (headerType === OmHeaderType.Legacy) {
+        variableData = headerBytes;
       }
     }
 
@@ -92,372 +68,136 @@ export class OmFileReader {
       throw new Error("Not a valid OM file");
     }
 
-    // Initialize variable
-    const variableDataPtr = this.wasm._malloc(variableData.length);
-    this.wasm.HEAPU8.set(variableData, variableDataPtr);
-    this.variable = this.wasm.om_variable_init(variableDataPtr);
-
-    if (!this.variable) {
-      this.wasm._free(variableDataPtr);
-      throw new Error("Failed to initialize variable");
-    }
-
-    this.variableDataPtr = variableDataPtr;
-
+    this.variable = new OmVariable(variableData);
     return this;
   }
 
-  // Helper method to convert C strings to JS strings
-  private _getString(strPtr: number, strLen: number): string {
-    const bytes = this.wasm.HEAPU8.subarray(strPtr, strPtr + strLen);
-    return new TextDecoder("utf8").decode(bytes);
+  dataType(): OmDataType {
+    if (this.variable === null) throw new Error("Reader not initialized");
+    return this.variable.getDataType() as unknown as OmDataType;
   }
 
-  dataType(): number {
+  compression(): OmCompression {
     if (this.variable === null) throw new Error("Reader not initialized");
-    return this.wasm.om_variable_get_type(this.variable);
-  }
-
-  compression(): number {
-    if (this.variable === null) throw new Error("Reader not initialized");
-    return this.wasm.om_variable_get_compression(this.variable);
+    return this.variable.getCompression();
   }
 
   scaleFactor(): number {
     if (this.variable === null) throw new Error("Reader not initialized");
-    return this.wasm.om_variable_get_scale_factor(this.variable);
+    return this.variable.getScaleFactor();
   }
 
   addOffset(): number {
     if (this.variable === null) throw new Error("Reader not initialized");
-    return this.wasm.om_variable_get_add_offset(this.variable);
+    return this.variable.getAddOffset();
   }
 
   getDimensions(): number[] {
     if (this.variable === null) throw new Error("Reader not initialized");
-
-    const count = Number(this.wasm.om_variable_get_dimensions_count(this.variable));
-    const dimensionsPtr = this.wasm.om_variable_get_dimensions_ptr(this.variable);
-
-    // Create view directly into WASM memory
-    const int64View = new BigInt64Array(this.wasm.HEAPU8.buffer, dimensionsPtr, count);
-    return Array.from(int64View, (bigIntVal) => Number(bigIntVal));
+    return Array.from(this.variable.getDimensions(), (v) => Number(v));
   }
 
   getChunkDimensions(): number[] {
     if (this.variable === null) throw new Error("Reader not initialized");
-
-    const count = Number(this.wasm.om_variable_get_dimensions_count(this.variable));
-    const chunksPtr = this.wasm.om_variable_get_chunks_ptr(this.variable);
-
-    // Create view directly into WASM memory
-    const int64View = new BigInt64Array(this.wasm.HEAPU8.buffer, chunksPtr, count);
-    return Array.from(int64View, (bigIntVal) => Number(bigIntVal));
+    return Array.from(this.variable.getChunks(), (v) => Number(v));
   }
 
   getName(): string | null {
     if (this.variable === null) throw new Error("Reader not initialized");
-
-    // string length is i16
-    const lengthPtr = this.wasm._malloc(2);
-    const valuePtr = this.wasm.om_variable_get_name_ptr(this.variable, lengthPtr);
-    const size = this.wasm.getValue(lengthPtr, "i16");
-    this.wasm._free(lengthPtr);
-    if (size === 0 || valuePtr === 0) {
-      return null;
-    }
-    return this._getString(valuePtr, size);
+    return this.variable.getName();
   }
 
   numberOfChildren(): number {
     if (this.variable === null) throw new Error("Reader not initialized");
-    return this.wasm.om_variable_get_children_count(this.variable);
+    return this.variable.getChildrenCount();
   }
 
   async getChild(index: number): Promise<OmFileReader | null> {
     if (this.variable === null) throw new Error("Reader not initialized");
-
-    // Allocate memory for the output parameters
-    const offsetPtr = this.wasm._malloc(8);
-    const sizePtr = this.wasm._malloc(8);
-
-    const success = this.wasm.om_variable_get_children(this.variable, index, 1, offsetPtr, sizePtr);
-
-    if (!success) {
-      this.wasm._free(offsetPtr);
-      this.wasm._free(sizePtr);
-      return null;
-    }
-
-    const offset = Number(this.wasm.getValue(offsetPtr, "i64"));
-    const size = Number(this.wasm.getValue(sizePtr, "i64"));
-
-    this.wasm._free(offsetPtr);
-    this.wasm._free(sizePtr);
-
-    return this.initChildFromOffsetSize({ offset, size });
+    const child = this.variable.getChild(index);
+    if (!child) return null;
+    return this.initChildFromOffsetSize({ offset: Number(child.offset), size: Number(child.size) });
   }
 
-  /**
-   * Searches direct children by name. Does not search recursively.
-   */
   async getChildByName(name: string): Promise<OmFileReader | null> {
-    // Check cache first
     const cachedMetadata = this.metadataCache.get(name);
-    if (cachedMetadata === null) {
-      return null;
-    }
-    if (cachedMetadata) {
-      return await this.initChildFromOffsetSize(cachedMetadata);
-    }
+    if (cachedMetadata === null) return null;
+    if (cachedMetadata) return this.initChildFromOffsetSize(cachedMetadata);
 
-    // Search through children and cache metadata
     const numChildren = this.numberOfChildren();
     for (let i = 0; i < numChildren; i++) {
-      const metadata = this._getChildMetadata(i);
-      if (metadata) {
-        const child = await this.initChildFromOffsetSize(metadata);
-        const childName = child.getName();
-        if (childName) {
-          this.metadataCache.set(childName, metadata);
-          if (childName === name) {
-            return child; // keep this one
-          }
-        }
-        child.dispose();
+      const child = this.variable!.getChild(i);
+      if (!child) continue;
+      const metadata = { offset: Number(child.offset), size: Number(child.size) };
+      const childReader = await this.initChildFromOffsetSize(metadata);
+      const childName = childReader.getName();
+      if (childName) {
+        this.metadataCache.set(childName, metadata);
+        if (childName === name) return childReader;
       }
+      childReader.dispose();
     }
-    // also remember invalid names
     this.metadataCache.set(name, null);
     return null;
   }
 
   async initChildFromOffsetSize(offsetSize: OffsetSize): Promise<OmFileReader> {
-    const childDataPtr = await this._readDataBlock(offsetSize.offset, offsetSize.size);
-
-    const childReader = new OmFileReader(this.backend, this.wasm);
-
-    childReader.variable = this.wasm.om_variable_init(childDataPtr);
-    childReader.variableDataPtr = childDataPtr;
-
+    const childData = await this.backend.getBytes(offsetSize.offset, offsetSize.size);
+    const childReader = new OmFileReader(this.backend);
+    childReader.variable = new OmVariable(childData);
     return childReader;
   }
 
-  /**
-   * Get child metadata by index.
-   */
-  private _getChildMetadata(index: number): OffsetSize | null {
-    if (this.variable === null) throw new Error("Reader not initialized");
-
-    // Allocate memory for the output parameters
-    const offsetPtr = this.wasm._malloc(8);
-    const sizePtr = this.wasm._malloc(8);
-
-    const success = this.wasm.om_variable_get_children(this.variable, index, 1, offsetPtr, sizePtr);
-
-    if (!success) {
-      this.wasm._free(offsetPtr);
-      this.wasm._free(sizePtr);
-      return null;
-    }
-
-    const offset = Number(this.wasm.getValue(offsetPtr, "i64"));
-    const size = Number(this.wasm.getValue(sizePtr, "i64"));
-
-    this.wasm._free(offsetPtr);
-    this.wasm._free(sizePtr);
-
-    return { offset, size };
-  }
-
-  /**
-   * Find a variable by its path (e.g., "parent/child/grandchild")
-   */
   async findByPath(path: string): Promise<OmFileReader | null> {
     const parts = path.split("/").filter((s) => s.length > 0);
-    return await this.navigatePath(parts);
+    return this.navigatePath(parts);
   }
 
-  /**
-   * Navigate through a path recursively
-   */
   async navigatePath(parts: string[]): Promise<OmFileReader | null> {
-    if (parts.length === 0) {
-      return null;
-    }
-
+    if (parts.length === 0) return null;
     const child = await this.getChildByName(parts[0]);
     if (child) {
-      if (parts.length === 1) {
-        return child;
-      } else {
-        return await child.navigatePath(parts.slice(1));
-      }
+      if (parts.length === 1) return child;
+      return child.navigatePath(parts.slice(1));
     }
     return null;
   }
 
-  // Method to read scalar values
   readScalar<T>(dataType: OmDataType): T | null {
     if (this.variable === null) throw new Error("Reader not initialized");
-
-    if (this.dataType() !== dataType) {
-      return null;
-    }
-
-    // Allocate memory for output parameters
-    const ptrPtr = this.wasm._malloc(4); // pointer to pointer
-    const sizePtr = this.wasm._malloc(8); // u64
-
-    try {
-      const error = this.wasm.om_variable_get_scalar(this.variable, ptrPtr, sizePtr);
-
-      if (error !== this.wasm.ERROR_OK) {
+    if (this.dataType() !== dataType) return null;
+    const result = this.variable.getScalarBytes();
+    if (!result) return null;
+    const { bytes } = result;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    switch (dataType) {
+      case OmDataType.Int8:
+        return view.getInt8(0) as T;
+      case OmDataType.Uint8:
+        return view.getUint8(0) as T;
+      case OmDataType.Int16:
+        return view.getInt16(0, true) as T;
+      case OmDataType.Uint16:
+        return view.getUint16(0, true) as T;
+      case OmDataType.Int32:
+        return view.getInt32(0, true) as T;
+      case OmDataType.Uint32:
+        return view.getUint32(0, true) as T;
+      case OmDataType.Int64:
+        return view.getBigInt64(0, true) as T;
+      case OmDataType.Uint64:
+        return view.getBigUint64(0, true) as T;
+      case OmDataType.Float:
+        return view.getFloat32(0, true) as T;
+      case OmDataType.Double:
+        return view.getFloat64(0, true) as T;
+      case OmDataType.String:
+        return new TextDecoder().decode(bytes) as T;
+      default:
         return null;
-      }
-
-      const dataPtr = this.wasm.getValue(ptrPtr, "*");
-
-      if (dataPtr === 0) {
-        return null;
-      }
-
-      // Read data based on type
-      let result: T | null;
-
-      // TODO: Support Int64 and Uint64
-      switch (dataType) {
-        case OmDataType.Int8:
-          result = this.wasm.getValue(dataPtr, "i8");
-          break;
-        case OmDataType.Uint8:
-          result = (this.wasm.getValue(dataPtr, "i8") & 0xff) as T;
-          break;
-        case OmDataType.Int16:
-          result = this.wasm.getValue(dataPtr, "i16");
-          break;
-        case OmDataType.Uint16:
-          result = (this.wasm.getValue(dataPtr, "i16") & 0xffff) as T;
-          break;
-        case OmDataType.Int32:
-          result = this.wasm.getValue(dataPtr, "i32");
-          break;
-        case OmDataType.Uint32:
-          result = (this.wasm.getValue(dataPtr, "i32") >>> 0) as T;
-          break;
-        case OmDataType.Int64:
-          result = this.wasm.getValue(dataPtr, "i64");
-          break;
-        case OmDataType.Uint64:
-          // convert to unsigned BigInt
-          {
-            const val = this.wasm.getValue(dataPtr, "i64");
-            result = (val & BigInt("0xFFFFFFFFFFFFFFFF")) as T;
-          }
-          break;
-        case OmDataType.Float:
-          result = this.wasm.getValue(dataPtr, "float");
-          break;
-        case OmDataType.Double:
-          result = this.wasm.getValue(dataPtr, "double");
-          break;
-        case OmDataType.String:
-          {
-            const size = Number(this.wasm.getValue(sizePtr, "i64"));
-            if (size === 0) {
-              return null;
-            }
-            result = this._getString(dataPtr, size) as T;
-          }
-          break;
-        default:
-          result = null;
-      }
-      return result;
-    } finally {
-      this.wasm._free(ptrPtr);
-      this.wasm._free(sizePtr);
     }
   }
 
-  private newIndexRead(decoderPtr: number): number {
-    // Size of OmDecoder_indexRead_t
-    const sizeOfRange = 16; // 8 bytes for lowerBound + 8 bytes for upperBound
-    const sizeOfIndexRead = 8 + 8 + sizeOfRange * 3; // offset + count + 3 range structs
-
-    // Allocate the memory
-    const indexReadPtr = this.wasm._malloc(sizeOfIndexRead);
-    this.wasm.om_decoder_init_index_read(decoderPtr, indexReadPtr);
-    return indexReadPtr;
-  }
-
-  private newDataRead(indexReadPtr: number): number {
-    // Size of OmDecoder_dataRead_t
-    const sizeOfRange = 16; // 8 bytes for lowerBound + 8 bytes for upperBound
-    const sizeOfDataRead = 8 + 8 + sizeOfRange * 3; // offset + count + 3 range structs
-
-    // Allocate the memory
-    const dataReadPtr = this.wasm._malloc(sizeOfDataRead);
-    this.wasm.om_decoder_init_data_read(dataReadPtr, indexReadPtr);
-    return dataReadPtr;
-  }
-
-  private allocateTypedArray<T extends keyof OmDataTypeToTypedArray>(
-    dataType: T,
-    size: number,
-    useSharedBuffer: boolean = false
-  ): OmDataTypeToTypedArray[T] {
-    if (useSharedBuffer && typeof SharedArrayBuffer === "undefined") {
-      throw new Error("SharedArrayBuffer is not available in this environment");
-    }
-
-    // Type-safe mapping of data types to their constructors and byte sizes
-    const typeInfo = {
-      [this.wasm.DATA_TYPE_INT8_ARRAY]: { constructor: Int8Array<ArrayBufferLike>, bytes: 1 },
-      [this.wasm.DATA_TYPE_UINT8_ARRAY]: { constructor: Uint8Array<ArrayBufferLike>, bytes: 1 },
-      [this.wasm.DATA_TYPE_INT16_ARRAY]: { constructor: Int16Array<ArrayBufferLike>, bytes: 2 },
-      [this.wasm.DATA_TYPE_UINT16_ARRAY]: { constructor: Uint16Array<ArrayBufferLike>, bytes: 2 },
-      [this.wasm.DATA_TYPE_INT32_ARRAY]: { constructor: Int32Array<ArrayBufferLike>, bytes: 4 },
-      [this.wasm.DATA_TYPE_UINT32_ARRAY]: { constructor: Uint32Array<ArrayBufferLike>, bytes: 4 },
-      [this.wasm.DATA_TYPE_INT64_ARRAY]: { constructor: BigInt64Array<ArrayBufferLike>, bytes: 8 },
-      [this.wasm.DATA_TYPE_UINT64_ARRAY]: { constructor: BigUint64Array<ArrayBufferLike>, bytes: 8 },
-      [this.wasm.DATA_TYPE_FLOAT_ARRAY]: { constructor: Float32Array<ArrayBufferLike>, bytes: 4 },
-      [this.wasm.DATA_TYPE_DOUBLE_ARRAY]: { constructor: Float64Array<ArrayBufferLike>, bytes: 8 },
-    } as const;
-
-    const info = typeInfo[dataType];
-    if (!info) {
-      throw new Error("Unsupported data type");
-    }
-    const byteLength = size * info.bytes;
-
-    if (useSharedBuffer) {
-      // In browsers, crossOriginIsolated must be true; in Node, it's undefined (so skip check)
-      if (
-        typeof SharedArrayBuffer === "undefined" ||
-        (typeof crossOriginIsolated !== "undefined" && !crossOriginIsolated)
-      ) {
-        throw new Error("SharedArrayBuffer is not available in this environment");
-      }
-      const sharedBuffer = new SharedArrayBuffer(byteLength);
-      return new info.constructor(sharedBuffer) as OmDataTypeToTypedArray[T];
-    } else {
-      const normalBuffer = new ArrayBuffer(byteLength);
-      return new info.constructor(normalBuffer) as OmDataTypeToTypedArray[T];
-    }
-  }
-
-  /**
-   * Reads data from the file and returns a new TypedArray of the requested type.
-   *
-   * @param options Options for reading, including:
-   *   - type: The data type to read.
-   *   - ranges: Array of dimension ranges to read.
-   *   - prefetch: Whether to prefetch data (default: true).
-   *   - intoSAB: Use SharedArrayBuffer for output (default: false).
-   *   - ioSizeMax: Maximum I/O size (default: 65536).
-   *   - ioSizeMerge: Merge threshold for I/O operations (default: 2048).
-   */
   async read<T extends keyof OmDataTypeToTypedArray>(
     options: OmFileReadOptions<T>
   ): Promise<OmDataTypeToTypedArray[T]> {
@@ -471,28 +211,13 @@ export class OmFileReader {
       ioSizeMerge = BigInt(2048),
       signal,
     } = options;
-
-    // Calculate output dimensions
-    const outDims = ranges.map((range) => Number(range.end - range.start));
+    const outDims = ranges.map((r) => r.end - r.start);
     const totalSize = outDims.reduce((a, b) => a * b, 1);
-
-    const output = this.allocateTypedArray(type, totalSize, intoSAB);
-
+    const output = this._allocateTypedArray(type, totalSize, intoSAB);
     await this.readInto({ type, output, ranges, ioSizeMax, ioSizeMerge, prefetch, prefetchConcurrency, signal });
     return output;
   }
 
-  /**
-   * Reads data into an existing TypedArray with specified dimension ranges.
-   *
-   * @param options Options for reading, including:
-   *   - type: The data type to read.
-   *   - output: The TypedArray to read data into.
-   *   - ranges: Array of dimension ranges to read.
-   *   - prefetch: Whether to prefetch data (default: true).
-   *   - ioSizeMax: Maximum I/O size (default: 65536).
-   *   - ioSizeMerge: Merge threshold for I/O operations (default: 2048).
-   */
   async readInto<T extends keyof OmDataTypeToTypedArray>(options: OmFileReadIntoOptions<T>): Promise<void> {
     const {
       type,
@@ -509,16 +234,12 @@ export class OmFileReader {
       throw new Error(`Invalid data type: expected ${this.dataType()}, got ${type}`);
     }
 
-    const nDims = ranges.length;
     const fileDims = this.getDimensions();
-
-    // Validate dimension counts
-    if (fileDims.length !== nDims) {
-      throw new Error(`Mismatched dimensions: file has ${fileDims.length}, request has ${nDims}`);
+    if (fileDims.length !== ranges.length) {
+      throw new Error(`Mismatched dimensions: file has ${fileDims.length}, request has ${ranges.length}`);
     }
 
-    // Verify output size before starting
-    const totalElements = ranges.reduce((acc, r) => acc * Number(r.end - r.start), 1);
+    const totalElements = ranges.reduce((acc, r) => acc * (r.end - r.start), 1);
     if (output.length < totalElements) {
       throw new Error(`Output array is too small: needs ${totalElements} elements, has ${output.length}`);
     }
@@ -527,273 +248,189 @@ export class OmFileReader {
       ranges,
       ioSizeMax,
       ioSizeMerge,
-      async (decoderPtr) => {
+      async (decoder) => {
         if (prefetch) {
-          await this.decodePrefetch(decoderPtr, prefetchConcurrency, signal);
+          await this._decodePrefetch(decoder, prefetchConcurrency, signal);
         }
-        await this.decode(decoderPtr, output, signal);
+        await this._decode(decoder, output as TypedArray, signal);
       },
       signal
     );
   }
 
-  /**
-   * Warms up the backend cache by requesting the necessary data blocks
-   * without decoding them or copying them to a TypedArray.
-   */
   async readPrefetch(options: OmFilePrefetchReadOptions): Promise<void> {
     const { ranges, prefetchConcurrency = 20, ioSizeMax = BigInt(65536), ioSizeMerge = BigInt(2048), signal } = options;
-
     await this._runWithDecoder(
       ranges,
       ioSizeMax,
       ioSizeMerge,
-      async (decoderPtr) => {
-        await this.decodePrefetch(decoderPtr, prefetchConcurrency, signal);
+      async (decoder) => {
+        await this._decodePrefetch(decoder, prefetchConcurrency, signal);
       },
       signal
     );
   }
 
-  private async decodePrefetch(decoderPtr: number, concurrency: number = 10, signal?: AbortSignal): Promise<void> {
+  private async _decodePrefetch(
+    decoder: ReturnType<typeof omDecoderInit> & object,
+    concurrency: number,
+    signal?: AbortSignal
+  ): Promise<void> {
     if (!this.backend.collectPrefetchTasks) return;
-
     const allTasks: Array<() => Promise<void>> = [];
-
     await this._iterateDataBlocks(
-      decoderPtr,
-      async (dataReadPtr) => {
-        const dataOffset = Number(this.wasm.getValue(dataReadPtr, "i64"));
-        const dataCount = Number(this.wasm.getValue(dataReadPtr + 8, "i64"));
-
-        const tasks = await this.backend.collectPrefetchTasks!(dataOffset, dataCount, signal);
+      decoder,
+      async (dataRead) => {
+        const tasks = await this.backend.collectPrefetchTasks!(dataRead.offset, dataRead.count, signal);
         allTasks.push(...tasks);
       },
       signal
     );
-
-    if (allTasks.length > 0) {
-      await runLimited(allTasks, concurrency, signal);
-    }
+    if (allTasks.length > 0) await runLimited(allTasks, concurrency, signal);
   }
 
-  private async decode(decoderPtr: number, outputArray: TypedArray, signal?: AbortSignal): Promise<void> {
-    const outputPtr = this.wasm._malloc(outputArray.byteLength);
-    const chunkBufferSize = Number(this.wasm.om_decoder_read_buffer_size(decoderPtr));
-    const chunkBufferPtr = this.wasm._malloc(chunkBufferSize);
-    const errorPtr = this.wasm._malloc(4); // Separate error ptr for the decode step
-    this.wasm.setValue(errorPtr, this.wasm.ERROR_OK, "i32");
+  private async _decode(
+    decoder: ReturnType<typeof omDecoderInit> & object,
+    output: TypedArray,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const chunkBufSize = omDecoderReadBufferSize(decoder);
+    const chunkBuf = new Uint8Array(chunkBufSize);
 
-    try {
-      await this._iterateDataBlocks(
-        decoderPtr,
-        async (dataReadPtr) => {
-          const dataOffset = Number(this.wasm.getValue(dataReadPtr, "i64"));
-          const dataCount = Number(this.wasm.getValue(dataReadPtr + 8, "i64"));
-          const chunkIndexPtr = dataReadPtr + 32; // offset(8), count(8), indexRange(16)
-
-          // Get the compressed data from the backend
-          const dataBlockPtr = await this._readDataBlock(dataOffset, dataCount, signal);
-
-          try {
-            const success = this.wasm.om_decoder_decode_chunks(
-              decoderPtr,
-              chunkIndexPtr,
-              dataBlockPtr,
-              BigInt(dataCount),
-              outputPtr,
-              chunkBufferPtr,
-              errorPtr
-            );
-
-            if (!success) {
-              throw new Error(`Decoder failed: error ${this.wasm.getValue(errorPtr, "i32")}`);
-            }
-          } finally {
-            this.wasm._free(dataBlockPtr);
-          }
-        },
-        signal
-      );
-
-      this.copyToTypedArray(outputPtr, outputArray);
-    } finally {
-      this.wasm._free(errorPtr);
-      this.wasm._free(chunkBufferPtr);
-      this.wasm._free(outputPtr);
-    }
+    await this._iterateDataBlocks(
+      decoder,
+      async (dataRead) => {
+        const data = await this.backend.getBytes(dataRead.offset, dataRead.count, signal);
+        const error = omDecodeChunks(decoder, dataRead.chunkIndex, data, output as any, chunkBuf);
+        if (error !== OmError.Ok) {
+          throw new Error(`Decoder failed with error ${error}`);
+        }
+      },
+      signal
+    );
   }
 
-  /**
-   * Internal helper to set up the decoder and execute a task.
-   * Handles memory allocation and cleanup for ranges and the decoder.
-   */
   private async _runWithDecoder(
     ranges: Range[],
     ioSizeMax: bigint,
     ioSizeMerge: bigint,
-    task: (decoderPtr: number) => Promise<void>,
+    task: (decoder: ReturnType<typeof omDecoderInit> & object) => Promise<void>,
     signal?: AbortSignal
   ): Promise<void> {
     throwIfAborted(signal);
     if (this.variable === null) throw new Error("Reader not initialized");
 
-    const nDims = ranges.length;
     const fileDims = this.getDimensions();
-
+    const nDims = ranges.length;
     if (fileDims.length !== nDims) {
       throw new Error(`Mismatched dimensions: file has ${fileDims.length}, request has ${nDims}`);
     }
 
-    const outDims = ranges.map((range) => range.end - range.start);
-
-    // Allocate memory for dimension arrays
-    const readOffsetPtr = this.wasm._malloc(nDims * 8);
-    const readCountPtr = this.wasm._malloc(nDims * 8);
-    const intoCubeOffsetPtr = this.wasm._malloc(nDims * 8);
-    const intoCubeDimensionPtr = this.wasm._malloc(nDims * 8);
-
-    try {
-      for (let i = 0; i < nDims; i++) {
-        if (ranges[i].start < 0 || ranges[i].end > fileDims[i] || ranges[i].start >= ranges[i].end) {
-          throw new Error(`Invalid range for dimension ${i}: ${JSON.stringify(ranges[i])}`);
-        }
-        this.wasm.setValue(readOffsetPtr + i * 8, BigInt(ranges[i].start), "i64");
-        this.wasm.setValue(readCountPtr + i * 8, BigInt(outDims[i]), "i64");
-        this.wasm.setValue(intoCubeOffsetPtr + i * 8, BigInt(0), "i64");
-        this.wasm.setValue(intoCubeDimensionPtr + i * 8, BigInt(outDims[i]), "i64");
+    for (let i = 0; i < nDims; i++) {
+      if (ranges[i].start < 0 || ranges[i].end > fileDims[i] || ranges[i].start >= ranges[i].end) {
+        throw new Error(`Invalid range for dimension ${i}: ${JSON.stringify(ranges[i])}`);
       }
-
-      const decoderPtr = this.wasm._malloc(this.wasm.sizeof_decoder);
-      try {
-        const error = this.wasm.om_decoder_init(
-          decoderPtr,
-          this.variable,
-          BigInt(nDims),
-          readOffsetPtr,
-          readCountPtr,
-          intoCubeOffsetPtr,
-          intoCubeDimensionPtr,
-          ioSizeMerge,
-          ioSizeMax
-        );
-
-        if (error !== this.wasm.ERROR_OK) {
-          throw new Error(`Decoder initialization failed: error code ${error}`);
-        }
-
-        // Run the specific work (decode or prefetch)
-        await task(decoderPtr);
-      } finally {
-        this.wasm._free(decoderPtr);
-      }
-    } finally {
-      this.wasm._free(readOffsetPtr);
-      this.wasm._free(readCountPtr);
-      this.wasm._free(intoCubeOffsetPtr);
-      this.wasm._free(intoCubeDimensionPtr);
     }
+
+    const readOffset = ranges.map((r) => r.start);
+    const readCount = ranges.map((r) => r.end - r.start);
+    const cubeOffset = readCount.map(() => 0);
+    const cubeDimensions = readCount.slice();
+
+    const lutInfo = this.variable.getLutInfo();
+    const isLegacy = this.variable.isLegacy();
+
+    const decoderVar = {
+      scaleFactor: this.variable.getScaleFactor(),
+      addOffset: this.variable.getAddOffset(),
+      dataType: this.variable.getDataType() as unknown as import("@openmeteo/file-format").OmDataType,
+      compression: this.variable.getCompression() as unknown as import("@openmeteo/file-format").OmCompression,
+      dimensions: Array.from(this.variable.getDimensions(), (v) => Number(v)),
+      chunks: Array.from(this.variable.getChunks(), (v) => Number(v)),
+      lutSize: lutInfo ? Number(lutInfo.lutSize) : 0,
+      lutOffset: lutInfo ? Number(lutInfo.lutOffset) : OM_HEADER_V1_SIZE,
+      isLegacy,
+    };
+
+    const decoder = omDecoderInit(
+      decoderVar,
+      nDims,
+      readOffset,
+      readCount,
+      cubeOffset,
+      cubeDimensions,
+      Number(ioSizeMerge),
+      Number(ioSizeMax)
+    );
+
+    if (typeof decoder === "number") {
+      throw new Error(`Decoder initialization failed: error ${decoder}`);
+    }
+
+    await task(decoder);
   }
 
   private async _iterateDataBlocks(
-    decoderPtr: number,
-    callback: (dataReadPtr: number, indexDataPtr: number, indexCount: bigint) => Promise<void>,
+    decoder: ReturnType<typeof omDecoderInit> & object,
+    callback: (dataRead: ReturnType<typeof omInitDataRead>) => Promise<void>,
     signal?: AbortSignal
   ): Promise<void> {
-    const errorPtr = this.wasm._malloc(4);
-    this.wasm.setValue(errorPtr, this.wasm.ERROR_OK, "i32");
+    const indexRead = omInitIndexRead(decoder);
 
-    const indexReadPtr = this.newIndexRead(decoderPtr);
+    while (omNextIndexRead(decoder, indexRead)) {
+      throwIfAborted(signal);
+      const indexData = await this.backend.getBytes(indexRead.offset, indexRead.count, signal);
+      const dataRead = omInitDataRead(indexRead);
 
-    try {
-      // Loop over index blocks
-      while (this.wasm.om_decoder_next_index_read(decoderPtr, indexReadPtr)) {
+      while (true) {
+        const { result, error } = omNextDataRead(decoder, dataRead, indexData);
+        if (error !== OmError.Ok) throw new Error(`Data read error: ${error}`);
+        if (!result) break;
         throwIfAborted(signal);
-        const indexOffset = Number(this.wasm.getValue(indexReadPtr, "i64"));
-        const indexCount = Number(this.wasm.getValue(indexReadPtr + 8, "i64"));
-
-        // Get bytes for index-read
-        const indexDataPtr = await this._readDataBlock(indexOffset, indexCount, signal);
-        const dataReadPtr = this.newDataRead(indexReadPtr);
-
-        try {
-          // Loop over data blocks described by this index block
-          while (
-            this.wasm.om_decoder_next_data_read(decoderPtr, dataReadPtr, indexDataPtr, BigInt(indexCount), errorPtr)
-          ) {
-            throwIfAborted(signal);
-            await callback(dataReadPtr, indexDataPtr, BigInt(indexCount));
-          }
-
-          // Check for errors after the data_read loop finishes for this index block
-          const error = this.wasm.getValue(errorPtr, "i32");
-          if (error !== this.wasm.ERROR_OK) {
-            throw new Error(`Data read iteration error: ${error}`);
-          }
-        } finally {
-          this.wasm._free(dataReadPtr);
-          this.wasm._free(indexDataPtr);
-        }
+        await callback(dataRead);
       }
-    } finally {
-      this.wasm._free(indexReadPtr);
-      this.wasm._free(errorPtr);
     }
   }
 
-  private async _readDataBlock(offset: number, size: number, signal?: AbortSignal): Promise<number> {
-    const data = await this.backend.getBytes(offset, size, signal);
-    const ptr = this.wasm._malloc(data.length);
-    this.wasm.HEAPU8.set(data, ptr);
-    return ptr;
+  private _allocateTypedArray<T extends keyof OmDataTypeToTypedArray>(
+    dataType: T,
+    size: number,
+    useSharedBuffer = false
+  ): OmDataTypeToTypedArray[T] {
+    const typeMap: Record<number, new (buf: ArrayBufferLike) => TypedArray> = {
+      [OmDataType.Int8Array]: Int8Array,
+      [OmDataType.Uint8Array]: Uint8Array,
+      [OmDataType.Int16Array]: Int16Array,
+      [OmDataType.Uint16Array]: Uint16Array,
+      [OmDataType.Int32Array]: Int32Array,
+      [OmDataType.Uint32Array]: Uint32Array,
+      [OmDataType.Int64Array]: BigInt64Array,
+      [OmDataType.Uint64Array]: BigUint64Array,
+      [OmDataType.FloatArray]: Float32Array,
+      [OmDataType.DoubleArray]: Float64Array,
+    };
+    const bytesMap: Record<number, number> = {
+      [OmDataType.Int8Array]: 1,
+      [OmDataType.Uint8Array]: 1,
+      [OmDataType.Int16Array]: 2,
+      [OmDataType.Uint16Array]: 2,
+      [OmDataType.Int32Array]: 4,
+      [OmDataType.Uint32Array]: 4,
+      [OmDataType.Int64Array]: 8,
+      [OmDataType.Uint64Array]: 8,
+      [OmDataType.FloatArray]: 4,
+      [OmDataType.DoubleArray]: 8,
+    };
+
+    const Ctor = typeMap[dataType as number];
+    if (!Ctor) throw new Error("Unsupported data type");
+    const byteLength = size * bytesMap[dataType as number];
+
+    const buf = useSharedBuffer ? new SharedArrayBuffer(byteLength) : new ArrayBuffer(byteLength);
+    return new Ctor(buf) as OmDataTypeToTypedArray[T];
   }
 
-  /**
-   * Helper method to copy data from WASM memory to a TypedArray with the correct type
-   */
-  private copyToTypedArray(sourcePtr: number, targetArray: TypedArray): void {
-    switch (targetArray.constructor) {
-      case Float32Array:
-        (targetArray as Float32Array).set(new Float32Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case Float64Array:
-        (targetArray as Float64Array).set(new Float64Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case Int8Array:
-        (targetArray as Int8Array).set(new Int8Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case Uint8Array:
-        (targetArray as Uint8Array).set(new Uint8Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case Int16Array:
-        (targetArray as Int16Array).set(new Int16Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case Uint16Array:
-        (targetArray as Uint16Array).set(new Uint16Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case Int32Array:
-        (targetArray as Int32Array).set(new Int32Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case Uint32Array:
-        (targetArray as Uint32Array).set(new Uint32Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case BigInt64Array:
-        (targetArray as BigInt64Array).set(new BigInt64Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      case BigUint64Array:
-        (targetArray as BigUint64Array).set(new BigUint64Array(this.wasm.HEAPU8.buffer, sourcePtr, targetArray.length));
-        break;
-      default:
-        throw new Error("Unsupported TypedArray type in copyToTypedArray");
-    }
-  }
-
-  // Clean up resources when done
   dispose(): void {
-    if (this.variableDataPtr !== null) {
-      this.wasm._free(this.variableDataPtr);
-      this.variableDataPtr = null;
-    }
     this.variable = null;
   }
 }

--- a/packages/file-reader/src/lib/OmFileReader.ts
+++ b/packages/file-reader/src/lib/OmFileReader.ts
@@ -296,18 +296,27 @@ export class OmFileReader {
   ): Promise<void> {
     const chunkBufSize = omDecoderReadBufferSize(decoder);
     const chunkBuf = new Uint8Array(chunkBufSize);
+    let totalDataReads = 0;
 
     await this._iterateDataBlocks(
       decoder,
       async (dataRead) => {
+        totalDataReads++;
         const data = await this.backend.getBytes(dataRead.offset, dataRead.count, signal);
         const error = omDecodeChunks(decoder, dataRead.chunkIndex, data, output as any, chunkBuf);
         if (error !== OmError.Ok) {
+          console.error(
+            `[OmFileReader] omDecodeChunks error=${error} at dataRead #${totalDataReads}: offset=${dataRead.offset} count=${dataRead.count} chunkIndex=[${dataRead.chunkIndex.lowerBound},${dataRead.chunkIndex.upperBound})`
+          );
           throw new Error(`Decoder failed with error ${error}`);
         }
       },
       signal
     );
+
+    if (totalDataReads === 0) {
+      console.warn("[OmFileReader] _decode: no data reads were performed (no chunks matched)");
+    }
   }
 
   private async _runWithDecoder(

--- a/packages/file-reader/src/lib/OmFileReader.ts
+++ b/packages/file-reader/src/lib/OmFileReader.ts
@@ -303,7 +303,13 @@ export class OmFileReader {
       async (dataRead) => {
         totalDataReads++;
         const data = await this.backend.getBytes(dataRead.offset, dataRead.count, signal);
-        const error = omDecodeChunks(decoder, dataRead.chunkIndex, data, output as Parameters<typeof omDecodeChunks>[3], chunkBuf);
+        const error = omDecodeChunks(
+          decoder,
+          dataRead.chunkIndex,
+          data,
+          output as Parameters<typeof omDecodeChunks>[3],
+          chunkBuf
+        );
         if (error !== OmError.Ok) {
           console.error(
             `[OmFileReader] omDecodeChunks error=${error} at dataRead #${totalDataReads}: offset=${dataRead.offset} count=${dataRead.count} chunkIndex=[${dataRead.chunkIndex.lowerBound},${dataRead.chunkIndex.upperBound})`
@@ -437,6 +443,11 @@ export class OmFileReader {
 
     const buf = useSharedBuffer ? new SharedArrayBuffer(byteLength) : new ArrayBuffer(byteLength);
     return new Ctor(buf) as OmDataTypeToTypedArray[T];
+  }
+
+  /** Returns the raw FlatBuffer bytes for this variable. Used by WASM benchmarks and diagnostics. */
+  getVariableData(): Uint8Array | null {
+    return this.variable?.data ?? null;
   }
 
   dispose(): void {


### PR DESCRIPTION
### Summary

As an experiment TurboPFor was ported to TypeScript, resulting in a new package `file-format`. However the resulting performance is noticeably slower (~5x) than the `wasm` version of the C library.

### Benchmarks:

For the benchmark a `dwd_icon` spatial file was taken, and iterated over 20 times, to compare the decoding speed.

```bash
stdout | src/tests/dwd_icon_debug.test.ts > Benchmark — TS vs WASM decode, dwd_icon temperature_2m > measures TS decoder throughput
[bench/TS] 20 iterations — median=42.7ms  avg=43.6ms  all=49, 42, 48, 43, 47, 44, 42, 43, 42, 43, 43, 43, 43, 43, 42, 42, 42, 42, 42, 47ms

stdout | src/tests/dwd_icon_debug.test.ts > Benchmark — TS vs WASM decode, dwd_icon temperature_2m > measures WASM decoder throughput
[bench/WASM] 20 iterations — median=8.7ms  avg=9.5ms  all=13, 11, 9, 12, 13, 11, 8, 8, 14, 9, 8, 7, 8, 9, 8, 7, 8, 10, 8, 9ms

[bench] TS vs WASM comparison (20 iterations each, dwd_icon temperature_2m):
  TS   avg: 42.8 ms
  WASM avg: 8.9 ms
  Ratio:    4.80x  (>1 = WASM faster, <1 = TS faster)
```