### PR TITLE
fix: dead code from OmHttpBackend and remove emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/@openmeteo/file-reader?label=@openmeteo/file-reader)](https://www.npmjs.com/package/@openmeteo/file-reader)
 [![npm version](https://img.shields.io/npm/v/@openmeteo/file-format-wasm?label=@openmeteo/file-format-wasm)](https://www.npmjs.com/package/@openmeteo/file-format-wasm)
 
-> **⚠️ Notice:** This package is still under construction and not fully production ready yet. API changes may occur and some features might be incomplete.
+> **Notice:** This package is still under construction and not fully production ready yet. API changes may occur and some features might be incomplete.
 
 ## Overview
 

--- a/packages/file-reader/src/lib/backends/OmHttpBackend.ts
+++ b/packages/file-reader/src/lib/backends/OmHttpBackend.ts
@@ -78,7 +78,7 @@ export class OmHttpBackend implements OmFileReaderBackend {
     }
 
     this.metadataPromise = (async () => {
-      const response = await fetchRetry(this.url, { method: "HEAD" }, this.timeoutMs ?? 5000, this.retries, signal);
+      const response = await fetchRetry(this.url, { method: "HEAD" }, this.timeoutMs, this.retries, signal);
 
       if (!response.ok) {
         throw new OmHttpBackendError(


### PR DESCRIPTION
Cleaned up two things I noticed while going through the code:

- Dropped a dead ?? 5000 fallback in OmHttpBackend.fetchMetadata this.timeoutMs is already guaranteed to be set by the constructor, so that fallback never fired.

- Removed the warning sign emoji from the readme notice (was ⚠️)